### PR TITLE
feat: daily session architecture + program tab bug fixes

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,205 @@
+# Architecture
+
+**Analysis Date:** 2026-03-23
+
+## Pattern Overview
+
+**Overall:** Monolithic client-server with AI-mediated command pattern
+
+**Key Characteristics:**
+- Single FastAPI server serves both the REST API and the built PWA static files
+- Claude acts as a "universal controller" -- user messages go to Claude, Claude's JSON response drives all side effects (profile updates, meal logging, memory writes, workout creation, Whoop tool calls)
+- Claude is invoked via CLI subprocess (`claude --print`), inheriting OAuth session from the host machine -- NOT via the Anthropic SDK directly
+- Context assembly is the central architectural concept: every chat request builds a text context string from ~8 data sources and injects it as system prompt appendix
+- SQLite with WAL mode is the sole data store; no caching layer, no message queue
+
+## Layers
+
+**Frontend (PWA):**
+- Purpose: Chat UI, workout tracking UI, offline set logging, layout rendering
+- Location: `frontend/src/`
+- Contains: React 19 + TypeScript components and screens
+- Depends on: Backend REST API via `frontend/src/api.ts`
+- Used by: User's phone browser
+
+**API Routes:**
+- Purpose: HTTP endpoints, request validation, response shaping, side-effect orchestration
+- Location: `server/routes/`
+- Contains: 11 FastAPI routers (chat, workout, video, profile, whoop, progress, layout, morning, program, meals, interview)
+- Depends on: Services layer, Models, Database
+- Used by: Frontend via `/api` prefix
+
+**Services:**
+- Purpose: Business logic, external integrations, data transformation
+- Location: `server/services/`
+- Contains: ClaudeService, whoop_service, whoop_tools, layout_service, video_service, notification_service, workout_sequencer, program_parser
+- Depends on: Claude CLI, Whoop API, ffmpeg, ntfy.sh
+- Used by: Route handlers
+
+**Models:**
+- Purpose: ORM definitions, database schema
+- Location: `server/models.py`
+- Contains: 13 SQLAlchemy models (Program, Workout, Exercise, Set, WhoopData, FormCheck, Conversation, UserProfile, SystemMemory, WhoopToken, WhoopSyncQueue, Meal, ExerciseCatalog, TrainingLog)
+- Depends on: SQLAlchemy Base from `server/database.py`
+- Used by: All routes and services
+
+**Database:**
+- Purpose: Connection management, session factory, per-user DB routing
+- Location: `server/database.py`
+- Contains: Engine creation, WAL pragma setup, `get_db()` dependency, multi-user context var routing
+- Depends on: SQLite, `server/config.py`
+- Used by: All routes via `Depends(get_db)`
+
+**Configuration:**
+- Purpose: Environment loading, timezone, date utilities
+- Location: `server/config.py`
+- Contains: `Settings` (pydantic-settings), `today_eastern()`, `TIMEZONE`
+- Depends on: `.env` file
+- Used by: Everything
+
+## Data Flow
+
+**Primary Chat Flow (PWA -> Claude -> Side Effects):**
+
+1. User types message in `frontend/src/screens/workout.tsx`, calls `api.chat(text, workoutId, date)`
+2. `POST /api/chat` hits `server/routes/chat.py::chat()`
+3. Route handler gathers 8+ data sources in parallel:
+   - `UserProfile` from DB
+   - `WhoopData` for today (triggers background sync if missing)
+   - Last 15 completed sets across recent workouts
+   - Last 10 `Conversation` rows for this date
+   - Active workout context (exercises + set completion counts)
+   - `SystemMemory` row with key `"training_plan"` (the training program)
+   - Today's meal totals (sum of calories/protein/carbs/fat)
+   - Last 15 `TrainingLog` entries (completions, notes, adjustments)
+4. `assemble_context()` in `server/services/claude_service.py` concatenates all sources into a single text string
+5. `ClaudeService.chat()` checks if Whoop is connected:
+   - **Without Whoop:** calls `_call_claude(system, message)` -- single subprocess
+   - **With Whoop:** calls `_call_claude_with_tools()` -- up to 3 iterative subprocesses with tool descriptions embedded in system prompt
+6. `_call_claude()` spawns `claude --print --model claude-sonnet-4-20250514 --append-system-prompt <system> -p <message>` as async subprocess, waits up to 120s
+7. Raw stdout is parsed: `_extract_json()` strips code fences and finds JSON object
+8. Response JSON is parsed for side-effect fields: `profile`, `memory_update`, `training_log_entry`, `meal`, `workout_plan`, `set_suggestion`, `layout`
+9. Route handler processes each side-effect:
+   - `profile` -> upsert `UserProfile`
+   - `memory_update` -> upsert `SystemMemory(key="training_plan")` (blocked if `training_log_entry` present)
+   - `training_log_entry` -> append to `TrainingLog` table
+   - `meal` -> insert `Meal` + trigger Whoop journal sync
+   - `workout_plan` -> `create_workout_from_plan()` creates `Workout`/`Exercise`/`Set` rows
+   - `layout` -> validated by `validate_layout()` (whitelist of 10 component types)
+10. User + assistant messages saved to `Conversation` table with date scope
+11. Response returned: `{response, layout, set_suggestion, workout_active, current_set, workout_id}`
+
+**Tool-Use Flow (Claude -> Whoop):**
+
+1. `_call_claude_with_tools()` appends tool descriptions to system prompt as markdown
+2. Claude is asked to include `"tool_calls"` array in its JSON response
+3. If tool_calls present, each is dispatched to `execute_whoop_tool()` in `server/services/whoop_tools.py`
+4. Tool handler map (`TOOL_HANDLERS`) routes to specific async functions (e.g., `handle_create_activity`)
+5. Each handler lazy-imports `get_whoop_client(db)` and calls Whoop API
+6. Results collected into `tool_results_summary` list
+7. Follow-up Claude subprocess spawned with tool results as message
+8. Loop repeats up to `MAX_TOOL_ITERATIONS = 3` times, or until no more tool_calls
+
+**State Management:**
+- Server-side only. No client-side state persistence except IndexedDB for offline sets and cached layouts
+- Conversation history scoped by date (not session ID) via `Conversation.date` column
+- Training program stored as raw markdown in `SystemMemory(key="training_plan")`
+- Training log is append-only (`TrainingLog` table)
+- Frontend maintains ephemeral React state; rehydrates from server on tab visibility change
+
+## Key Abstractions
+
+**ClaudeService:**
+- Purpose: Wraps all Claude CLI interactions
+- File: `server/services/claude_service.py`
+- Pattern: Stateless service class instantiated per-request (`ClaudeService()`)
+- Methods: `chat()`, `generate_interview_questions()`, `analyze_form()`
+
+**assemble_context():**
+- Purpose: Build the complete context string from all data sources
+- File: `server/services/claude_service.py` (lines 187-293)
+- Pattern: Free function, takes 11 parameters, returns concatenated string
+- Critical: This is the primary mechanism for giving Claude knowledge about the user. Every piece of data Claude sees flows through here.
+
+**SystemMemory:**
+- Purpose: Key-value store for persistent AI state
+- File: `server/models.py` (line 101)
+- Pattern: Single-row per key. Key `"training_plan"` holds the full training program as markdown. Other keys used for onboarding flags (`whoop_first_workout_shown`, `whoop_journal_education_shown`, `whoop_status`)
+
+**TrainingLog:**
+- Purpose: Append-only log of training events (completions, notes, adjustments)
+- File: `server/models.py` (line 155)
+- Pattern: Separated from SystemMemory to prevent Claude from accidentally overwriting the training program when logging a workout completion
+
+**workout_sequencer:**
+- Purpose: Manages the set-by-set workout flow
+- File: `server/services/workout_sequencer.py`
+- Pattern: Creates Workout/Exercise/Set records from Claude's `workout_plan` array, tracks set completion order, provides `get_next_set()` for the UI
+
+## Entry Points
+
+**FastAPI Server:**
+- Location: `server/main.py` (line 140: `app = create_app()`)
+- Triggers: `uvicorn server.main:app --host 127.0.0.1 --port 8000`
+- Responsibilities: Registers all 11 routers under `/api`, serves frontend static files, runs startup migrations (inline ALTER TABLE for schema evolution)
+
+**Morning Briefing Script:**
+- Location: `server/scripts/morning_briefing.py`
+- Triggers: systemd timer at 07:00 daily (`deploy/spotme-morning.timer`)
+- Responsibilities: Calls `/api/whoop/sync` then `/api/morning?notify=true` to push morning notification
+
+**CLI Entry Point:**
+- Location: `server/cli.py`
+- Triggers: `python -m server.cli whoop_sync`
+- Responsibilities: Background whoop sync with dedup (3-hour window) and auth failure tracking
+
+**Frontend SPA:**
+- Location: `frontend/src/main.tsx` -> `frontend/src/App.tsx`
+- Triggers: Browser navigation to server root
+- Responsibilities: Renders Onboarding or 4-tab app (workout/program/diet/profile)
+
+## Error Handling
+
+**Strategy:** Defensive with graceful degradation. Every external call wrapped in try/except.
+
+**Patterns:**
+- Claude CLI failure: Returns hardcoded fallback response `"Having trouble reaching Claude right now. Try again in a sec."` (`server/services/claude_service.py` line 317)
+- Claude JSON parse failure: Returns raw text as response with all optional fields null (`server/services/claude_service.py` line 321)
+- Whoop API failure: Queues to `WhoopSyncQueue` table for retry (max 3 retries), app continues without Whoop data (`server/services/whoop_service.py` line 173)
+- Whoop tool failure: Returns `{"error": str(e)}` to Claude for graceful response (`server/services/whoop_tools.py` line 89-90)
+- Invalid layout from Claude: Falls back to `None` layout, frontend renders text-only (`server/services/layout_service.py`)
+- Frontend offline: IndexedDB queues sets for sync on reconnect (`frontend/src/hooks/use-offline.ts`)
+
+## Cross-Cutting Concerns
+
+**Logging:**
+- Python stdlib `logging` module used throughout
+- Logger per module: `logger = logging.getLogger(__name__)`
+- No structured logging, no log aggregation
+- CLI configures basic format: `%(asctime)s %(name)s %(message)s`
+
+**Validation:**
+- Request validation via Pydantic schemas in `server/schemas.py`
+- Layout validation via whitelist in `server/services/layout_service.py`
+- No validation of Claude's side-effect fields (profile, meal, etc.) beyond `isinstance` checks
+- No input sanitization for SQL (SQLAlchemy ORM handles parameterization)
+
+**Authentication:**
+- No app-level auth. Tailscale VPN is the auth boundary
+- Multi-user support via URL prefix `/u/{user_id}/` routed by `UserRoutingMiddleware` to per-user SQLite databases
+- Whoop auth via Cognito (stored in `WhoopToken` table)
+- Claude auth via CLI OAuth session on host machine
+
+**Date Handling:**
+- All dates as ISO strings (`YYYY-MM-DD`) in Eastern timezone
+- `today_eastern()` in `server/config.py` is the canonical date source
+- Frontend mirrors with `todayEastern()` using `toLocaleDateString('en-CA', { timeZone: 'America/New_York' })`
+
+**Background Tasks:**
+- Whoop biometric sync triggered lazily on first chat of the day (`_maybe_trigger_whoop_sync`)
+- Uses `loop.create_task()` for fire-and-forget background work
+- systemd timers handle scheduled jobs (morning briefing, whoop sync every 4 hours)
+
+---
+
+*Architecture analysis: 2026-03-23*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,232 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-03-23
+
+## Tech Debt
+
+### Claude CLI Subprocess Architecture (Critical)
+
+- Issue: Every chat request spawns a fresh `claude --print` subprocess (a 227MB ELF binary at `/home/deck/.local/share/claude/versions/2.1.81`). There is no connection pooling, no session reuse, and no persistent process. Each invocation loads the entire Claude Code runtime, authenticates via stored OAuth credentials in `~/.claude/.credentials.json`, makes an HTTPS request to the Anthropic API, then exits.
+- Files: `server/services/claude_service.py` lines 396-417 (`_call_claude`), lines 423-468 (`_call_claude_with_tools`)
+- Impact:
+  - **RAM**: Each subprocess consumes ~100-200MB RSS. On a Steam Deck with 14GB RAM (10GB in use, 7.7GB swap consumed), even 2-3 concurrent requests could push the system into heavy swapping.
+  - **Latency**: Process startup overhead (loading a 227MB binary, initializing Node.js runtime, reading OAuth tokens, establishing TLS connection) adds 2-5 seconds per call before any API work begins.
+  - **Tool-use loop**: `_call_claude_with_tools` (line 445) spawns up to 3 **sequential** subprocess invocations per single user request — each with full startup cost. A tool-use chat request can take 30-90 seconds.
+  - **No streaming**: The `--print` flag requires the full response to complete before returning. With a 120-second timeout (line 407), the user sees nothing until the entire response is ready.
+- Fix approach: Replace `claude --print` subprocess calls with direct use of the `anthropic` Python SDK (already listed as a dependency in `pyproject.toml`: `"anthropic>=0.40"`). This eliminates process spawning entirely:
+  ```python
+  # current: subprocess per call
+  proc = await asyncio.create_subprocess_exec(CLAUDE_BIN, "--print", ...)
+
+  # target: single async client, persistent connection
+  client = anthropic.AsyncAnthropic()  # uses ANTHROPIC_API_KEY env var
+  response = await client.messages.create(model=MODEL, system=system, messages=[...])
+  ```
+  The SDK supports streaming (`client.messages.stream()`), connection reuse via httpx connection pooling, and native tool-use without the text-based workaround. The `ANTHROPIC_API_KEY` is already configured in `server/config.py` line 4 as `anthropic_api_key`.
+
+### Text-Based Tool-Use Workaround
+
+- Issue: Instead of using the Anthropic API's native tool-use protocol (`tools` parameter in messages API), the code embeds tool descriptions as text in the system prompt (lines 432-441) and asks Claude to return `tool_calls` as a JSON array in its text response. This is fragile — tool calls depend on Claude correctly formatting JSON within its response text, and the server must parse them from the response.
+- Files: `server/services/claude_service.py` lines 432-468
+- Impact: Tool calls can fail silently if Claude doesn't format the JSON correctly. The follow-up message (line 450) loses conversation context — each tool iteration is a fresh stateless call with only the tool results, not the original user message or conversation history. Native tool-use maintains conversation state across tool calls.
+- Fix approach: Use `anthropic.AsyncAnthropic` with the `tools` parameter. The SDK handles tool-use turns natively with proper `tool_use` and `tool_result` content blocks:
+  ```python
+  response = await client.messages.create(
+      model=MODEL, system=system, messages=messages,
+      tools=[{"name": "...", "description": "...", "input_schema": {...}}],
+  )
+  # SDK returns tool_use blocks directly, no JSON parsing needed
+  ```
+
+### Stale `ClaudeService` Constructor Signatures
+
+- Issue: `ClaudeService` has no `__init__` method and does not accept any parameters, but two call sites pass `api_key=settings.anthropic_api_key` as a keyword argument.
+- Files:
+  - `server/routes/video.py` line 20: `ClaudeService(api_key=settings.anthropic_api_key)`
+  - `server/routes/layout.py` line 19: `ClaudeService(api_key=settings.anthropic_api_key)`
+- Impact: These `api_key` arguments are silently ignored. The class works only because it delegates to `_call_claude()` which uses the CLI binary (inheriting OAuth from the filesystem). The `api_key` parameter is a vestige from when the service used the Anthropic SDK directly.
+- Fix approach: Either add `__init__(self, api_key=None)` to `ClaudeService` or remove the `api_key=` arguments from call sites. When migrating to the SDK, the `api_key` parameter becomes meaningful again.
+
+### Inline Schema Migrations in `main.py`
+
+- Issue: `server/main.py` lines 43-100 contain 15+ `ALTER TABLE` statements wrapped in column-existence checks, executed on every app startup. This is a manual migration system running alongside (and duplicating) the Alembic migration framework already configured in `alembic/`.
+- Files: `server/main.py` lines 43-100
+- Impact: These migrations run on every cold start, adding ~100ms of startup latency. More critically, they can conflict with Alembic migrations — if Alembic adds a column that also exists in the startup code, one or the other will error or silently no-op. The pattern also doesn't support rollbacks.
+- Fix approach: Convert all inline `ALTER TABLE` statements to proper Alembic migrations. Remove the startup migration code from `create_app()`. Run `alembic upgrade head` as a deployment step.
+
+### `UserRoutingMiddleware` Per-User Database Without Migrations
+
+- Issue: `server/database.py` lines 32-51 create per-user SQLite databases (`spotme_{user_id}.db`) on first access via `_get_user_engine()`. These databases get `Base.metadata.create_all()` but skip all the inline migrations in `main.py` (calorie_target, protein_target, conversation date, set columns, meal columns, whoop columns).
+- Files: `server/database.py` lines 32-51, `server/main.py` lines 43-100
+- Impact: Per-user databases lack columns that the main database has. Any query touching those columns will crash with `OperationalError: no such column`. The feature appears partially implemented — the middleware exists but the migration gap makes it broken for real use.
+- Fix approach: Either remove the per-user database feature if unused, or ensure migrations run against all user databases (another argument for consolidating into Alembic).
+
+## Security Considerations
+
+### SQL Injection via `ilike` in Exercise Catalog Search
+
+- Risk: `server/services/whoop_tools.py` line 63-64 passes user-controlled `query` directly into an `ilike` pattern without escaping SQL wildcards:
+  ```python
+  query = params["query"].lower()
+  results = db.query(ExerciseCatalog).filter(
+      ExerciseCatalog.name.ilike(f"%{query}%")
+  )
+  ```
+  The `query` string originates from Claude's tool-call arguments, which are AI-generated text based on user input. While SQLAlchemy parameterizes the value (preventing SQL injection), the `%` and `_` wildcards within the LIKE pattern are not escaped — a query containing `%` will match everything.
+- Files: `server/services/whoop_tools.py` lines 63-64
+- Current mitigation: SQLAlchemy parameterization prevents actual SQL injection. The risk is limited to unexpected wildcard matching.
+- Recommendations: Escape `%` and `_` in the query string before building the LIKE pattern.
+
+### Silent Exception Swallowing
+
+- Risk: Multiple `except Exception: pass` blocks silently discard errors with no logging, making failures invisible.
+- Files:
+  - `server/routes/chat.py` lines 40-41: Whoop sync failure silently ignored
+  - `server/routes/chat.py` lines 271-272: Journal sync failure silently ignored
+  - `server/routes/layout.py` lines 23-24: Claude layout generation failure silently ignored
+- Current mitigation: The app continues functioning (graceful degradation for Whoop).
+- Recommendations: Add `logger.debug()` or `logger.warning()` to every bare `except` block. Silent failures make debugging production issues nearly impossible.
+
+### CORS Wildcard
+
+- Risk: `server/main.py` line 38 sets `allow_origins=["*"]` which permits any origin to make authenticated requests.
+- Files: `server/main.py` line 38
+- Current mitigation: The app has no authentication — Tailscale is the auth boundary. This is acceptable for the current single-user deployment but would be a critical issue if the app were exposed publicly.
+- Recommendations: Restrict CORS to the Tailscale IP range or the known frontend origin when moving beyond single-user.
+
+## Performance Bottlenecks
+
+### Chat Endpoint Response Time
+
+- Problem: A single `/api/chat` request with Whoop connected triggers: 6 DB queries for context assembly, 1-3 Claude CLI subprocess spawns (each 5-30 seconds), plus DB writes for conversation, profile, meal, training log, and onboarding flags. Total wall time is 10-60 seconds.
+- Files: `server/routes/chat.py` lines 82-280, `server/services/claude_service.py` lines 298-335
+- Cause: Sequential subprocess calls with full startup overhead per call. The chat endpoint also does synchronous DB queries within an async handler.
+- Improvement path:
+  1. Migrate to Anthropic SDK (eliminates process startup, enables streaming)
+  2. Use streaming responses (`text/event-stream`) so the user sees tokens as they arrive
+  3. Move post-response side effects (Whoop sync, onboarding flags) to background tasks
+
+### Context Assembly Does N+1 Queries
+
+- Problem: `assemble_context()` in `server/services/claude_service.py` lines 187-293 accepts a `db` parameter and performs additional queries inline (HRV average at line 239, stale data check at line 248, WhoopToken check at line 257, ExerciseCatalog check at line 259, SystemMemory checks at lines 265-277). The caller in `server/routes/chat.py` has already queried most of this data.
+- Files: `server/services/claude_service.py` lines 236-277, `server/routes/chat.py` lines 82-170
+- Cause: Context assembly grew organically — new features added new queries inside the function rather than passing data in from the route.
+- Improvement path: Have the route handler fetch all needed data upfront and pass it to `assemble_context()` as parameters. Remove `db` parameter from `assemble_context()` entirely — a pure function that takes data and returns a string.
+
+### `_maybe_trigger_whoop_sync` Creates Uncollected Background Tasks
+
+- Problem: `server/routes/chat.py` lines 22-47 creates a fire-and-forget async task via `loop.create_task(_do_sync())`. The task creates its own `SessionLocal()` database session. If the task fails, the exception is silently swallowed. If the task takes long, there is no tracking or timeout.
+- Files: `server/routes/chat.py` lines 22-47
+- Cause: Background Whoop sync was added as a quick fix to avoid blocking the chat response.
+- Improvement path: Use FastAPI's `BackgroundTasks` dependency instead of raw `loop.create_task()`. This integrates with the framework's lifecycle and error handling.
+
+## Fragile Areas
+
+### JSON Parsing from Claude CLI Output
+
+- Files: `server/services/claude_service.py` lines 379-393 (`_extract_json`), lines 318-321 (fallback on parse failure)
+- Why fragile: The `_extract_json` function uses regex to find JSON in Claude's text output, handling code fences (`\`\`\`json ... \`\`\``), raw JSON, and embedded JSON. This is necessary because `claude --print` returns raw text that may include markdown formatting. Any change to Claude CLI's output format (adding prefixes, changing fence format) breaks parsing.
+- Safe modification: When migrating to the SDK, `_extract_json` becomes unnecessary — the SDK returns structured `Message` objects with typed content blocks.
+- Test coverage: `tests/test_claude_sdk.py` covers basic JSON and fenced JSON extraction. No test for malformed JSON within otherwise valid output.
+
+### Tool-Use Context Loss Between Iterations
+
+- Files: `server/services/claude_service.py` lines 445-468
+- Why fragile: Each tool-use iteration calls `_call_claude()` with a fresh system prompt + message. The follow-up (line 450) sends only tool results — it does not include the original user message, prior Claude response, or any conversation state. Claude must reconstruct intent from tool results alone. This frequently causes responses that lose the original question's context.
+- Safe modification: Accumulate messages across iterations. When migrating to SDK, use the native multi-turn conversation format where each tool-use/tool-result pair is a message in the conversation.
+- Test coverage: `tests/test_claude_sdk.py` has one tool-use test but does not test context preservation across iterations.
+
+### `ensure_future` for Journal Sync
+
+- Files: `server/routes/chat.py` line 270
+- Why fragile: `asyncio.ensure_future(sync_journal_to_whoop(db, request_date))` passes the **same** `db` session to a background coroutine. The session was yielded by `get_db()` and will be closed when the request handler returns (via the `finally: db.close()` in `server/database.py` line 63). The background task may try to use a closed session, causing `StatementError` or `ObjectDeletedError`.
+- Safe modification: Create a new `SessionLocal()` for background tasks (like `_maybe_trigger_whoop_sync` does on line 36). Better yet, use FastAPI `BackgroundTasks`.
+- Test coverage: No test covers this race condition.
+
+## Scaling Limits
+
+### SQLite Concurrent Write Locking
+
+- Current capacity: Single-user app with sequential requests. WAL mode enabled (`server/database.py` line 19) with 5-second busy timeout (line 20).
+- Limit: SQLite allows only one writer at a time. With WAL mode, readers don't block writers, but concurrent writes queue behind the 5-second timeout. If a long Claude response (up to 120 seconds) holds a transaction, other writes will timeout with `OperationalError: database is locked`.
+- Scaling path: The current single-user, single-device use case is fine. If adding multi-user support, switch to PostgreSQL or add explicit write serialization. The per-user database approach in `server/database.py` partially addresses this by isolating user data.
+
+### Claude CLI Process Concurrency
+
+- Current capacity: The Steam Deck has 14GB RAM total, ~4.4GB available. Each `claude --print` subprocess uses ~100-200MB.
+- Limit: More than ~10 concurrent chat requests would consume available memory. With the tool-use loop potentially spawning 3 processes per request, 3-4 concurrent users could exhaust memory.
+- Scaling path: Migrate to the Anthropic SDK — a single persistent `httpx.AsyncClient` handles unlimited concurrent requests with ~0 additional memory per request.
+
+### Context Size Growth
+
+- Current capacity: Estimated ~4,200 tokens per request (system prompt: ~1,900 tokens, context assembly: ~2,100 tokens, tool descriptions: ~225 tokens). Well within the ~4,000-token target mentioned in `CLAUDE.md`.
+- Limit: The training plan (`system_memory.content`) is currently 2,649 chars (~660 tokens). If a user stores a detailed multi-month program, this could grow to 10,000+ chars. The history window is capped at 10 messages (line 291) with 200-char truncation per message (line 291), limiting that axis. Training log shows last 15 entries (line 216). These caps are reasonable.
+- Scaling path: Add explicit token counting before sending to Claude. Truncate or summarize the training plan if it exceeds a threshold. Consider a sliding window for training log entries based on recency and relevance.
+
+## Dependencies at Risk
+
+### Claude Code CLI as API Gateway
+
+- Risk: The entire AI integration depends on `claude --print`, a CLI tool designed for interactive developer use, not as a programmatic API gateway. CLI output format, authentication flow, and command-line flags can change between versions without notice. The current version is 2.1.81.
+- Impact: Any Claude Code update could break the app's core functionality. There is no version pinning — the binary at `/home/deck/.local/bin/claude` is a symlink to the latest installed version.
+- Migration plan: Replace with `anthropic` Python SDK (`anthropic>=0.40`, already in dependencies). The SDK has a stable, versioned API with semantic versioning guarantees. This is the single highest-priority migration.
+
+### `whoop-write-api` (Reverse-Engineered)
+
+- Risk: Installed from git (`git+https://github.com/jd1207/whoop-write-api.git`). Uses Cognito auth against Whoop's undocumented internal API. Can break when Whoop updates their API or auth flow.
+- Impact: Whoop integration stops working. The app is designed to degrade gracefully (lazy imports, try/except everywhere), so core functionality continues.
+- Migration plan: Already well-mitigated by the graceful degradation pattern. Monitor for breakage. No official Whoop write API exists.
+
+## Missing Critical Features
+
+### No Request Rate Limiting
+
+- Problem: No rate limiting on any endpoint. A misbehaving client (or accidental rapid taps in the PWA) could spawn dozens of concurrent Claude subprocesses.
+- Blocks: Safe deployment to multiple users. A single user accidentally double-tapping the send button spawns two expensive Claude calls.
+- Fix: Add a semaphore or rate limiter. Simplest approach: `asyncio.Semaphore(2)` around Claude calls to limit concurrent subprocesses.
+
+### No Response Streaming
+
+- Problem: The `claude --print` flag requires the full response before returning. Users wait 10-60 seconds with no feedback.
+- Blocks: Good UX during workout sessions where the user is between sets and needs quick responses.
+- Fix: The Anthropic SDK supports streaming via `client.messages.stream()`. Return a `StreamingResponse` from FastAPI. The frontend already handles text display incrementally.
+
+### No Health Check or Process Monitoring
+
+- Problem: No `/health` endpoint. No monitoring of running Claude subprocesses. No alerting when the system is under memory pressure.
+- Blocks: Reliable operation as a systemd service. If the service OOMs, systemd restarts it but there is no early warning.
+- Fix: Add a `/health` endpoint that reports memory usage, active subprocess count, and database connectivity. Configure systemd `MemoryMax=` to prevent OOM kills.
+
+## Test Coverage Gaps
+
+### No Integration Test for Full Chat Flow
+
+- What's not tested: The `/api/chat` endpoint's full flow (context assembly, Claude call, profile save, meal save, training log save, Whoop sync) is not tested end-to-end. Individual pieces are tested in isolation.
+- Files: `tests/test_chat.py` tests `assemble_context` and helper functions. `tests/test_claude_sdk.py` tests `_call_claude` and `_call_claude_with_tools` with mocked subprocesses. No test creates a `ChatRequest`, POSTs to `/api/chat`, and verifies all side effects.
+- Risk: Regressions in the interaction between context assembly, Claude response parsing, and database writes go undetected.
+- Priority: High
+
+### No Test for Concurrent Request Handling
+
+- What's not tested: Behavior when multiple chat requests arrive simultaneously — subprocess resource exhaustion, SQLite locking, session sharing between background tasks.
+- Files: No file covers this.
+- Risk: The app could OOM or deadlock under concurrent load with no test to catch it.
+- Priority: Medium (single-user app, but double-tap is a real scenario)
+
+### No Test for Background Task Session Safety
+
+- What's not tested: The `ensure_future(sync_journal_to_whoop(db, ...))` pattern in `server/routes/chat.py` line 270 shares a database session with a background task that outlives the request.
+- Files: `tests/test_chat.py` does not test background task execution.
+- Risk: `StatementError` or `ObjectDeletedError` in production when the background task uses the closed session.
+- Priority: High
+
+### No Test for Claude CLI Timeout/Kill
+
+- What's not tested: The timeout path in `_call_claude` (lines 408-411) kills the process and raises `RuntimeError`. No test verifies that the process is actually cleaned up and that the error propagates correctly through `ClaudeService.chat()` to the route handler's catch-all.
+- Files: `tests/test_claude_sdk.py` tests CLI error (non-zero exit) but not the timeout path.
+- Risk: Orphaned claude processes accumulating if `proc.kill()` doesn't fully terminate the process tree.
+- Priority: Medium
+
+---
+
+*Concerns audit: 2026-03-23*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,240 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-03-23
+
+## Naming Patterns
+
+**Files:**
+- snake_case for all Python files: `claude_service.py`, `workout_sequencer.py`, `program_parser.py`
+- Test files mirror source with `test_` prefix: `test_chat.py`, `test_claude_sdk.py`, `test_whoop.py`
+- Routes named for the resource: `server/routes/chat.py`, `server/routes/workout.py`
+- Services named for the integration: `server/services/claude_service.py`, `server/services/whoop_service.py`
+
+**Functions:**
+- snake_case everywhere: `assemble_context()`, `get_next_set()`, `push_workout_to_whoop()`
+- Private helpers prefixed with `_`: `_call_claude()`, `_extract_json()`, `_get_today_whoop()`, `_find_plan()`
+- Route handler names match the HTTP path: `chat()` for `/chat`, `morning_briefing()` for `/morning`
+- Async for all route handlers and Claude/Whoop calls. Sync for pure DB operations.
+
+**Variables:**
+- snake_case: `recovery_score`, `workout_plan`, `meal_totals`
+- Constants are UPPER_SNAKE_CASE: `SYSTEM_PROMPT`, `CLAUDE_BIN`, `MODEL`, `MAX_TOOL_ITERATIONS`, `VALID_COMPONENT_TYPES`
+- Abbreviations kept lowercase: `db`, `hrv`, `rpe`, `e1rm`
+
+**Types/Classes:**
+- PascalCase: `ClaudeService`, `ChatRequest`, `ChatResponse`, `WhoopData`
+- SQLAlchemy models are singular nouns: `Program`, `Workout`, `Exercise`, `Set`, `Meal`
+- Pydantic schemas use Request/Response suffix: `ChatRequest`, `WorkoutCompleteResponse`
+
+## Code Style
+
+**Formatting:**
+- ruff listed in dev dependencies (`pyproject.toml`) but no `[tool.ruff]` config section defined
+- No `.prettierrc`, `.editorconfig`, or formatting config files detected
+- Implicit 4-space indentation (Python standard)
+- No enforced line length -- some lines exceed 120 chars
+
+**Linting:**
+- ruff available but no explicit rule config
+- No pre-commit hooks or CI pipeline configured
+
+## Import Organization
+
+**Order (observed pattern):**
+1. Standard library: `import asyncio`, `import json`, `import logging`, `import re`
+2. Third-party: `from fastapi import APIRouter`, `from sqlalchemy.orm import Session`
+3. Internal: `from server.database import get_db`, `from server.models import Workout`
+
+**Lazy imports for unstable dependencies:**
+```python
+# whoop is ALWAYS lazy-imported inside functions
+async def sync_whoop(db):
+    try:
+        from whoop import WhoopClient
+        # ... use client
+    except (ImportError, Exception):
+        return {"error": str(e)}
+```
+This pattern is mandatory for the `whoop` package. See `server/services/whoop_tools.py` and `server/services/whoop_service.py`.
+
+**Path Aliases:**
+- None. All imports use full paths from `server.*` root.
+
+## Claude Integration Pattern
+
+**Subprocess-based, not SDK:**
+Claude is invoked via CLI subprocess (`claude --print`), NOT the Anthropic Python SDK. This is because SpotMe uses Claude Code's OAuth session rather than an API key.
+
+```python
+# server/services/claude_service.py, lines 396-417
+CLAUDE_BIN = shutil.which("claude") or "/home/deck/.local/bin/claude"
+
+async def _call_claude(system_prompt: str, message: str) -> str:
+    proc = await asyncio.create_subprocess_exec(
+        CLAUDE_BIN, "--print",
+        "--model", MODEL,
+        "--append-system-prompt", system_prompt,
+        "-p", message,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
+    # ...
+    raw = stdout.decode().strip()
+    return _extract_json(raw)
+```
+
+**Response schema (Claude JSON contract):**
+```json
+{
+  "response": "coaching text (required)",
+  "layout": null,
+  "set_suggestion": null,
+  "profile": null,
+  "memory_update": null,
+  "training_log_entry": null,
+  "meal": null,
+  "workout_plan": null,
+  "journal_signals": null
+}
+```
+All fields except `response` are optional. `ClaudeService.chat()` in `server/services/claude_service.py` (lines 318-335) extracts each field with `.get()` and returns a normalized dict.
+
+**JSON extraction from CLI output:**
+`_extract_json()` in `server/services/claude_service.py` (lines 379-393) strips markdown fences and extracts JSON from mixed text. Handles:
+- Raw JSON starting with `{`
+- Code-fenced JSON: `` ```json {...} ``` ``
+- JSON embedded in prose text
+
+**Error handling cascade:**
+1. Subprocess failure (non-zero exit) -> `RuntimeError`
+2. Timeout (120s) -> process killed, `RuntimeError`
+3. `ClaudeService.chat()` catches all exceptions -> returns fallback dict with error message
+4. JSON parse failure -> returns raw text as `response` with all other fields null
+
+**Tool use (Whoop tools):**
+Tool descriptions are embedded in the system prompt text (not native Claude tool_use). Claude returns `tool_calls` array in JSON. Max 3 tool iterations. See `_call_claude_with_tools()` in `server/services/claude_service.py` (lines 423-468).
+
+## Context Assembly
+
+`assemble_context()` in `server/services/claude_service.py` (lines 187-293) builds a text context string. Order:
+1. User profile (or "NO USER PROFILE YET" prompt)
+2. Training memory (stored program)
+3. Training log (last 15 entries)
+4. Active workout context
+5. Whoop biometrics with recovery zone
+6. HRV trend (7-day average comparison)
+7. Stale data flag
+8. Tool/catalog availability flags
+9. Onboarding education messages
+10. Recent set history (last 15 completed sets)
+11. Today's meal totals
+12. Conversation history (last 10 messages)
+
+## Error Handling
+
+**Patterns:**
+
+**Graceful degradation for external services:**
+```python
+# whoop calls always wrapped in try/except
+try:
+    result = await push_workout_to_whoop(db, workout.id)
+except ImportError:
+    whoop_error = "whoop-write-api not installed"
+except Exception as e:
+    whoop_error = str(e)
+```
+
+**Failed syncs queue for retry:**
+```python
+# server/services/whoop_service.py
+def _queue_failed_sync(db, workout_id, date, error, sync_type="workout"):
+    db.add(WhoopSyncQueue(
+        workout_id=workout_id,
+        payload=json.dumps({"date": date}),
+        status="pending",
+        last_error=str(error),
+        sync_type=sync_type,
+    ))
+```
+
+**Claude fallback response pattern:**
+```python
+return {
+    "response": "Having trouble reaching Claude right now. Try again in a sec.",
+    "layout": None, "profile": None, "memory_update": None,
+    "training_log_entry": None, "set_suggestion": None, "meal": None, "workout_plan": None,
+}
+```
+
+## Logging
+
+**Framework:** Python `logging` module
+
+**Pattern:**
+```python
+logger = logging.getLogger(__name__)
+# lowercase messages, no periods, format strings with %s
+logger.error("claude call failed: %s", e)
+logger.warning("whoop tool %s failed: %s", name, e)
+logger.info("queued failed whoop sync for workout %s", workout_id)
+```
+
+## Comments
+
+**When to Comment:**
+- Inline comments are rare and lowercase
+- Docstrings used sparingly for non-obvious functions
+- Section comments with `# --` separators in test files
+
+**Docstring style:**
+```python
+async def _call_claude_with_tools(...) -> str:
+    """call claude with tool-use via CLI, parsing tool calls from JSON response."""
+```
+
+## Function Design
+
+**Size:** Most functions are under 50 lines. `chat()` route handler in `server/routes/chat.py` is the longest at ~200 lines (orchestrates many side effects).
+
+**Parameters:** Use keyword arguments for optional params. DB session always via `Depends(get_db)` in routes.
+
+**Return Values:** Route handlers return dicts or Pydantic models. Service functions return dicts with status fields like `{"synced": True}` or `{"error": "message"}`.
+
+## Module Design
+
+**Exports:** No `__all__` definitions. Imports are explicit.
+
+**Barrel Files:** `server/routes/__init__.py` and `server/services/__init__.py` are empty. Routers are imported individually in `server/main.py`.
+
+## Database Patterns
+
+**Session management:**
+- Routes use `db: Session = Depends(get_db)` dependency injection
+- In-memory SQLite with `StaticPool` for tests
+- `dependency_overrides[get_db]` to inject test sessions
+
+**Mutation pattern:** Direct attribute assignment on ORM objects, then `db.commit()`:
+```python
+if memory_row:
+    memory_row.content = memory_update
+else:
+    db.add(SystemMemory(key=MEMORY_KEY, content=memory_update))
+db.commit()
+```
+
+**Date handling:** All dates stored as ISO strings (`YYYY-MM-DD`), converted via `today_eastern()` from `server/config.py`.
+
+## Route Registration
+
+All routers registered in `server/main.py` under `/api` prefix:
+```python
+app.include_router(chat_router, prefix="/api")
+app.include_router(workout_router, prefix="/api")
+# ... etc
+```
+
+---
+
+*Convention analysis: 2026-03-23*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,326 @@
+# External Integrations
+
+**Analysis Date:** 2026-03-23
+
+## APIs & External Services
+
+### Claude AI (Primary Integration)
+
+**Architecture Decision: CLI subprocess, NOT SDK**
+
+The codebase uses `claude --print` as a subprocess rather than the `anthropic` Python SDK for all AI inference. The `anthropic>=0.40` pip dependency in `pyproject.toml` is vestigial and unused in the main chat flow.
+
+**Why CLI over SDK:**
+- Claude Code CLI handles OAuth authentication automatically (no API key management)
+- Inherits the user's Claude Code session/subscription
+- No need to provision or pay for a separate Anthropic API key
+- Trade-off: each request spawns a full OS process (~100-300MB RAM per invocation)
+
+**Binary Location:**
+- Resolved at import time: `shutil.which("claude") or "/home/deck/.local/bin/claude"` in `server/services/claude_service.py` line 10
+- Current version: 2.1.81, symlinked from `/home/deck/.local/share/claude/versions/2.1.81`
+
+**Subprocess Lifecycle:**
+
+```python
+# server/services/claude_service.py, _call_claude() at line 396
+proc = await asyncio.create_subprocess_exec(
+    CLAUDE_BIN, "--print",
+    "--model", MODEL,
+    "--append-system-prompt", system_prompt,
+    "-p", message,
+    stdout=asyncio.subprocess.PIPE,
+    stderr=asyncio.subprocess.PIPE,
+)
+stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
+```
+
+**Lifecycle details:**
+1. **Spawn:** `asyncio.create_subprocess_exec()` forks a new process for every request
+2. **Communication:** Pipes stdout/stderr, waits for full completion (no streaming)
+3. **Timeout:** 120 seconds hard limit via `asyncio.wait_for()`
+4. **Cleanup on timeout:** `proc.kill()` then `await proc.wait()` ensures zombie cleanup
+5. **Error handling:** Non-zero exit raises `RuntimeError`, caught by `ClaudeService.chat()`
+6. **Output parsing:** `_extract_json()` strips code fences and extracts JSON from raw text
+
+**Concurrency Model:**
+- No process pooling or reuse. Each request spawns a fresh `claude` process.
+- No concurrency limiter (semaphore/lock). Multiple simultaneous chat requests each spawn their own subprocess.
+- The tool-use loop (`_call_claude_with_tools()` at line 423) can spawn up to `MAX_TOOL_ITERATIONS = 3` sequential subprocesses per single user request.
+- With Whoop tools connected, a single chat request may invoke 1-3 Claude CLI processes sequentially.
+
+**RAM Implications:**
+- Each `claude --print` process loads the full Claude Code runtime (Node.js + dependencies)
+- Estimated ~100-300MB RSS per process during execution
+- On a Steam Deck (16GB RAM), 2-3 concurrent chat requests could consume 300-900MB
+- No process caching or warm-starting between requests
+- Processes are short-lived (typical response in 5-30s) and fully cleaned up after
+
+**Model:**
+- `claude-sonnet-4-20250514` defined as `MODEL` constant at `server/services/claude_service.py` line 11
+- Change in one place only
+
+**Auth/OAuth:**
+- Claude CLI uses its own OAuth session stored in `~/.claude/`
+- No API key needed or used for the main chat flow
+- Docker mounts `~/.claude:/root/.claude:ro` to share host credentials
+- `anthropic_api_key` in `server/config.py` exists but is only referenced by legacy routes (`server/routes/layout.py` line 17, `server/routes/video.py` line 20) that pass it to `ClaudeService(api_key=...)` -- these routes appear to be older code paths
+
+**Invocation Points (all in `server/services/claude_service.py`):**
+- `ClaudeService.chat()` at line 298 - Main chat endpoint, calls `_call_claude()` or `_call_claude_with_tools()`
+- `ClaudeService.generate_interview_questions()` at line 337 - Onboarding interview
+- `ClaudeService.analyze_form()` at line 372 - Video form analysis
+- `_call_claude_with_tools()` at line 423 - Tool-use loop for Whoop integration (up to 3 iterations)
+
+**Tool-Use Implementation:**
+- NOT using Claude's native tool_use API. Tools are described in the system prompt as text.
+- Claude returns `tool_calls` as a JSON array in its response body.
+- Tool execution happens server-side via `execute_whoop_tool()` in `server/services/whoop_tools.py`.
+- Results are fed back as a follow-up message in the next iteration.
+- Maximum 3 tool iterations per request (`MAX_TOOL_ITERATIONS` at line 420).
+
+**Context Assembly:**
+- `assemble_context()` at line 187 builds a text string from: profile, training memory, training log, active workout, Whoop biometrics, HRV trends, set history, meal totals, conversation history
+- System prompt is ~120 lines of coaching rules + context
+- Last 10 messages of history included (line 290)
+- Target: keep context under ~4000 tokens per request
+
+### Whoop API (Biometrics & Activity Tracking)
+
+**SDK/Client:** `whoop-write-api` (reverse-engineered, installed from git)
+- Repository: `https://github.com/jd1207/whoop-write-api`
+- Optional dependency group: `pip install -e ".[whoop]"`
+- Version: v0.4 with Cognito auth (not OAuth)
+
+**Auth:**
+- Cognito login via `CognitoAuth().login(email, password)` in `server/routes/whoop.py` line 39
+- Tokens stored in `WhoopToken` table (access_token, refresh_token, expires_at)
+- `get_whoop_client(db)` in `server/services/whoop_service.py` line 18 creates a client with auto-refresh callback
+- Token refresh persisted to DB via `persist_refreshed_tokens` callback
+- Consecutive auth failures tracked in `SystemMemory` key `whoop_status` (`server/cli.py` line 47)
+
+**Integration Pattern (CRITICAL):**
+```python
+# correct: lazy import inside function, wrapped in try/except
+async def some_function(db):
+    try:
+        from whoop import WhoopClient
+        client = get_whoop_client(db)
+        # ... do work
+    except (ImportError, Exception) as e:
+        return {"error": str(e)}
+
+# WRONG: never import at module top level
+from whoop import WhoopClient  # breaks if lib not installed
+```
+
+**Concurrency:**
+- `_sync_lock = asyncio.Lock()` in `server/services/whoop_service.py` line 15 prevents concurrent biometric syncs
+- Staleness threshold: 2 hours (`STALENESS_THRESHOLD = 7200`) -- skips sync if data is fresh
+- Background sync triggered lazily from chat route via `_maybe_trigger_whoop_sync()` at `server/routes/chat.py` line 22
+
+**Data Flows:**
+
+1. **Biometric Sync (read):**
+   - Trigger: systemd timer every 4h, or lazily from chat route
+   - `sync_whoop_biometrics()` at `server/services/whoop_service.py` line 46
+   - Fetches: recovery, sleep, strain (cycles)
+   - Backfills from last synced date
+   - Stores in `WhoopData` table
+
+2. **Workout Push (write):**
+   - Trigger: workout completion at `server/routes/workout.py` line 152
+   - `push_workout_to_whoop()` at `server/services/whoop_service.py` line 127
+   - Sends: `DetailedExercise` with `ExerciseSet` data
+   - On failure: queued to `WhoopSyncQueue` for retry (max 3 retries)
+
+3. **Journal Sync (write):**
+   - Trigger: meal logged with `journal_signals` at `server/routes/chat.py` line 265
+   - `sync_journal_to_whoop()` at `server/services/whoop_service.py` line 289
+   - Sends: caffeine count, alcohol flag, late meal flag, protein
+
+4. **Tool Execution (read/write):**
+   - Trigger: Claude includes `tool_calls` in response during chat
+   - `execute_whoop_tool()` at `server/services/whoop_tools.py` line 82
+   - Handlers: create_activity, update_weight, set_alarm, delete_activity, list_activities, search_catalog
+   - Each handler lazy-imports whoop client
+
+**Graceful Degradation:**
+- App must work 100% without Whoop installed or connected
+- Whoop availability determined by presence of `WhoopToken` row, NOT env vars
+- All Whoop calls wrapped in try/except
+- Failed syncs queued to `WhoopSyncQueue` with error details
+- `process_whoop_queue()` retries pending items (max 3 attempts)
+- Exercise catalog populated on first login, best-effort
+
+### ntfy.sh (Push Notifications)
+
+- Service: ntfy.sh (self-hosted or public)
+- Used for: Morning briefing push notifications
+- Client: `httpx.AsyncClient` in `server/services/notification_service.py`
+- Auth: Topic name stored in `ntfy_topic` setting (env var)
+- Triggered by: systemd timer at 07:00 via `server/scripts/morning_briefing.py`
+
+## Data Storage
+
+**Databases:**
+- SQLite with WAL mode
+  - Main DB: `sqlite:///./spotme.db` (configurable via `DATABASE_URL` env var)
+  - Per-user DBs: `sqlite:///./spotme_{user_id}.db` (multi-user support)
+  - Connection: `server/config.py` Settings class, `server/database.py`
+  - ORM: SQLAlchemy 2.x with sync `Session` (NOT async engine)
+  - WAL pragma + busy_timeout=5000ms set on every connection via event listener
+  - `check_same_thread=False` for FastAPI async compatibility
+  - Per-user engine cache: `_user_engines` dict in `server/database.py` line 27
+
+**SQLite Connection Patterns:**
+```python
+# server/database.py
+engine = create_engine(
+    settings.database_url,
+    connect_args={"check_same_thread": False, "timeout": 30},
+)
+SessionLocal = sessionmaker(bind=engine)
+
+# dependency injection pattern used everywhere:
+def get_db():
+    user_id = _current_user.get()  # contextvars for multi-user
+    if user_id:
+        eng = _get_user_engine(user_id)
+        db = sessionmaker(bind=eng)()
+    else:
+        db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+```
+
+**Multi-User Routing:**
+- `UserRoutingMiddleware` in `server/main.py` line 15 strips `/u/{user_id}/` prefix
+- Sets `_current_user` contextvar so `get_db()` returns the correct user's database
+- User ID validated: `^[a-zA-Z0-9_-]{1,32}$`
+- Engine cache: engines created per-user and cached in `_user_engines` dict (never evicted)
+
+**Schema Migrations:**
+- Alembic configured (`alembic.ini`, `alembic/` directory)
+- ALSO: inline `ALTER TABLE` migrations in `server/main.py` `create_app()` (lines 43-93) for columns added after initial schema
+- Tables auto-created via `Base.metadata.create_all()` for new user databases
+
+**Tables (16 total, defined in `server/models.py`):**
+- `programs` - Training program metadata
+- `workouts` - Workout sessions with date, type, status
+- `exercises` - Exercises within workouts
+- `sets` - Individual sets with targets and actuals
+- `whoop_data` - Cached biometric data per date
+- `form_checks` - Video analysis results
+- `conversations` - Chat history with date scoping
+- `user_profiles` - Athlete profile and nutrition targets
+- `system_memory` - Key-value store (training plan, onboarding flags, whoop status)
+- `whoop_tokens` - Cognito auth tokens
+- `whoop_sync_queue` - Failed sync retry queue
+- `meals` - Meal logs with macros and journal signals
+- `exercise_catalog` - Cached Whoop exercise catalog
+- `training_log` - Append-only training log entries (completions, notes, adjustments)
+
+**File Storage:**
+- Videos saved to `VIDEO_DIR` (default `./videos`)
+- ffmpeg extracts frames to temp directory, returned as base64
+
+**Caching:**
+- No Redis/Memcached
+- Whoop biometric data cached in SQLite with staleness check (2h threshold)
+- Exercise catalog cached in `exercise_catalog` table
+- Frontend: IndexedDB for offline sets, cached layouts, cached workouts (`frontend/src/db.ts`)
+- Frontend: Workbox service worker caches API responses (NetworkFirst, 1h TTL, 50 entries)
+
+## Authentication & Identity
+
+**Auth Provider:** None (Tailscale network boundary)
+- No app-level auth -- Tailscale VPN is the auth boundary
+- Multi-user support via URL prefix `/u/{user_id}/` but no password/token auth
+- Each user gets their own SQLite database file
+
+**Claude Auth:** OAuth via Claude Code CLI
+- CLI manages its own OAuth session in `~/.claude/`
+- No API key needed for main chat flow
+- Docker: mount `~/.claude:/root/.claude:ro`
+
+**Whoop Auth:** AWS Cognito
+- Email/password login via `CognitoAuth().login()`
+- Tokens stored in `WhoopToken` table per user database
+- Auto-refresh via callback in `get_whoop_client()`
+
+## Monitoring & Observability
+
+**Error Tracking:**
+- None (no Sentry, Datadog, etc.)
+- Errors logged to stdout via Python `logging` module
+
+**Logs:**
+- Python `logging` with `logger = logging.getLogger(__name__)` pattern
+- systemd journal: `journalctl --user -u spotme -f`
+- CLI jobs: `logging.basicConfig(level=logging.INFO)` in `server/cli.py`
+
+## CI/CD & Deployment
+
+**Hosting:**
+- Steam Deck (primary): systemd user service, Tailscale for remote access
+- Docker (alternative): `Dockerfile` and `docker-compose.yml` available
+
+**CI Pipeline:**
+- None detected (no GitHub Actions, no CI config files)
+
+**Deploy Process (Steam Deck):**
+```bash
+systemctl --user restart spotme      # restart server
+journalctl --user -u spotme -f       # tail logs
+```
+
+**systemd Services (`deploy/`):**
+- `spotme.service` - Main uvicorn server on `127.0.0.1:8000`
+- `spotme-whoop-sync.service` + `.timer` - Whoop sync every 4 hours
+- `spotme-morning.service` + `.timer` - Morning briefing at 07:00
+
+## Environment Configuration
+
+**Required env vars:**
+- `DATABASE_URL` - SQLite connection string (default: `sqlite:///./spotme.db`)
+
+**Optional env vars:**
+- `ANTHROPIC_API_KEY` - Only used by legacy layout/video routes, NOT by main chat
+- `VIDEO_DIR` - Video upload directory (default: `./videos`)
+- `NTFY_TOPIC` - ntfy.sh push notification topic
+
+**Secrets location:**
+- `.env` file at project root (loaded by pydantic-settings)
+- Whoop tokens stored in database (WhoopToken table)
+- Claude OAuth credentials in `~/.claude/` (managed by CLI)
+
+## Webhooks & Callbacks
+
+**Incoming:**
+- None (no webhook endpoints)
+
+**Outgoing:**
+- ntfy.sh POST for morning notifications (`server/services/notification_service.py`)
+- Morning briefing script calls own API via loopback (`server/scripts/morning_briefing.py` hits `http://127.0.0.1:8000/api/`)
+
+## Process & Resource Summary
+
+**Per chat request resource usage:**
+- 1 Claude CLI subprocess (no tools) or 1-3 sequential subprocesses (with tools)
+- Each subprocess: ~100-300MB RAM, 5-30s typical duration, 120s hard timeout
+- No process pooling, no warm cache, no connection reuse
+- SQLite session opened/closed per request via `get_db()` dependency
+
+**Scaling considerations:**
+- Single-user design (one person at the gym)
+- Multi-user support exists but no concurrency limiting on Claude subprocess spawning
+- SQLite WAL mode allows concurrent reads but serializes writes
+- No rate limiting on API endpoints
+- Steam Deck has 16GB RAM -- practical limit of ~3-5 concurrent Claude processes
+
+---
+
+*Integration audit: 2026-03-23*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,118 @@
+# Technology Stack
+
+**Analysis Date:** 2026-03-23
+
+## Languages
+
+**Primary:**
+- Python 3.11+ - Backend API, business logic, CLI tools (`server/`, `tests/`)
+- TypeScript ~5.9.3 - Frontend PWA (`frontend/src/`)
+
+**Secondary:**
+- SQL (SQLite dialect) - Database queries, migrations (`alembic/`)
+- Bash - systemd service files, deploy scripts (`deploy/`)
+
+## Runtime
+
+**Environment:**
+- Python 3.11+ (production runs in `.venv` at `~/spotme/.venv/bin/`)
+- Node.js 20 (build-time only for frontend; Docker uses `node:20-slim`)
+- Claude Code CLI 2.1.81 installed at `/home/deck/.local/bin/claude` (symlink to `/home/deck/.local/share/claude/versions/2.1.81`)
+
+**Package Manager:**
+- pip with hatchling build backend (`pyproject.toml`)
+- npm with lockfile (`frontend/package-lock.json`)
+- Lockfile: present for frontend, not used for Python (no `requirements.txt` or `pip.lock`)
+
+## Frameworks
+
+**Core:**
+- FastAPI >=0.110 - HTTP API server (`server/main.py`)
+- React 19.2.4 - Frontend UI (`frontend/src/`)
+- SQLAlchemy 2.0+ - ORM and database access (`server/models.py`, `server/database.py`)
+
+**Testing:**
+- pytest >=8.0 - Test runner (`tests/`)
+- pytest-asyncio >=0.23 - Async test support (mode: `auto`)
+- httpx >=0.27 - HTTP client for route testing
+
+**Build/Dev:**
+- Vite 8.0 - Frontend bundler and dev server (`frontend/vite.config.ts`)
+- vite-plugin-pwa 1.2.0 - Service worker and PWA manifest generation
+- Workbox 7.4.0 - Runtime caching in service worker
+- ruff >=0.3 - Python linting
+- ESLint 9 + typescript-eslint - TypeScript linting (`frontend/eslint.config.js`)
+
+## Key Dependencies
+
+**Critical:**
+- `claude` CLI binary (2.1.81) - All AI inference runs through `claude --print` subprocess, NOT the Anthropic Python SDK. The `anthropic>=0.40` pip dependency exists in `pyproject.toml` but is NOT used for API calls. See INTEGRATIONS.md for full details.
+- `fastapi>=0.110` - HTTP framework (`server/main.py`)
+- `sqlalchemy>=2.0` - All database access (`server/database.py`, `server/models.py`)
+- `pydantic-settings>=2.0` - Config loading from `.env` (`server/config.py`)
+
+**Infrastructure:**
+- `uvicorn>=0.27` - ASGI server (`deploy/spotme.service`)
+- `alembic>=1.13` - Database migrations (`alembic/`, `alembic.ini`)
+- `httpx` - Used for ntfy.sh notifications (`server/services/notification_service.py`) and morning briefing script (`server/scripts/morning_briefing.py`)
+- `python-multipart>=0.0.9` - File upload handling for video analysis (`server/routes/video.py`)
+- `python-dotenv>=1.0` - `.env` file loading
+
+**Optional:**
+- `whoop-write-api` - Reverse-engineered Whoop integration, installed from git (`git+https://github.com/jd1207/whoop-write-api.git`). Optional dependency group: `pip install -e ".[whoop]"`. Always lazy-imported inside functions, never at module top level.
+
+**Frontend:**
+- `react` 19.2.4, `react-dom` 19.2.4 - UI rendering
+- `workbox-window` 7.4.0 - Service worker registration
+- `@vitejs/plugin-react` 6.0 - React Fast Refresh for Vite
+
+## Configuration
+
+**Environment:**
+- Config loaded via `pydantic_settings.BaseSettings` in `server/config.py`
+- `.env` file at project root (existence confirmed; contents not read)
+- `.env.example` declares: `DATABASE_URL`, `VIDEO_DIR`
+- `anthropic_api_key` field exists in Settings but is unused by the main chat flow (Claude CLI uses OAuth instead)
+- `ntfy_topic` - Push notification topic for ntfy.sh
+- Timezone hardcoded: `America/New_York` in `server/config.py`
+
+**Build:**
+- `pyproject.toml` - Python package config with hatchling backend
+- `frontend/vite.config.ts` - Vite + PWA plugin config
+- `frontend/tsconfig.app.json` - TypeScript strict mode, ES2023 target, `verbatimModuleSyntax: true`
+- `alembic.ini` - Migration config pointing to `alembic/` directory
+
+## Platform Requirements
+
+**Development:**
+- Python 3.11+
+- Node.js 20+ (for frontend build)
+- Claude Code CLI installed and authenticated via OAuth
+- ffmpeg (runtime dependency for video frame extraction)
+- SQLite 3.x (ships with Python)
+
+**Production (Steam Deck):**
+- Arch Linux-based, read-only rootfs
+- All installs to `~/.local/bin`
+- Runs as systemd user service (not root): `deploy/spotme.service`
+- Accessible via Tailscale (no app-level auth)
+- uvicorn bound to `127.0.0.1:8000`
+- Claude CLI at `/home/deck/.local/bin/claude`
+- PATH must include `~/.local/bin` for Claude CLI access
+
+**Docker (alternative):**
+- Multi-stage build: `node:20-slim` for frontend, `python:3.12-slim` for backend
+- Claude Code CLI installed in container via curl or npm
+- Claude credentials mounted read-only: `~/.claude:/root/.claude:ro`
+- Persistent data volume at `/data/spotme.db`
+- Exposed on port 8000
+
+## Scheduled Jobs
+
+**systemd timers (deploy/):**
+- `spotme-whoop-sync.timer` - Whoop biometric sync every 4 hours (`00,04,08,12,16,20:00`)
+- `spotme-morning.timer` - Morning briefing with push notification at 07:00 daily
+
+---
+
+*Stack analysis: 2026-03-23*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,314 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-03-23
+
+## Directory Layout
+
+```
+spotme/
+├── server/                    # Python FastAPI backend
+│   ├── main.py                # App factory, middleware, router registration, inline migrations
+│   ├── config.py              # Settings (pydantic-settings), timezone, today_eastern()
+│   ├── database.py            # SQLAlchemy engine, session factory, per-user DB routing
+│   ├── models.py              # 13 SQLAlchemy ORM models
+│   ├── schemas.py             # Pydantic request/response DTOs
+│   ├── utils.py               # recovery_zone() helper
+│   ├── cli.py                 # CLI entry point for background jobs (whoop_sync)
+│   ├── routes/                # FastAPI routers (11 files)
+│   │   ├── chat.py            # POST /chat, GET /chat/history, /chat/days, /chat/day
+│   │   ├── workout.py         # Workout CRUD, set logging, completion
+│   │   ├── program.py         # GET /program, /program/week/{n}
+│   │   ├── progress.py        # GET /progress, /progress/prs
+│   │   ├── meals.py           # Meal CRUD, daily/weekly totals
+│   │   ├── morning.py         # GET /morning briefing
+│   │   ├── profile.py         # GET/POST /profile
+│   │   ├── whoop.py           # Whoop login, sync, status, retry
+│   │   ├── interview.py       # POST /interview/questions
+│   │   ├── video.py           # POST /video (form check upload + analysis)
+│   │   └── layout.py          # GET /layout (Claude-generated layouts)
+│   ├── services/              # Business logic (7 files)
+│   │   ├── claude_service.py  # ClaudeService, assemble_context(), _call_claude(), tool loop
+│   │   ├── whoop_service.py   # Biometric sync, workout push, journal sync, queue processing
+│   │   ├── whoop_tools.py     # Tool handler dispatch for Claude's tool_calls
+│   │   ├── workout_sequencer.py # Set-by-set workout management
+│   │   ├── program_parser.py  # Markdown program parsing into structured weeks/days
+│   │   ├── layout_service.py  # Layout validation (component type whitelist)
+│   │   ├── video_service.py   # FFmpeg frame extraction
+│   │   └── notification_service.py # ntfy.sh push notifications
+│   └── scripts/               # Standalone scripts for systemd timers
+│       └── morning_briefing.py # HTTP client that hits /api/whoop/sync then /api/morning
+├── frontend/                  # React 19 + TypeScript PWA
+│   ├── src/
+│   │   ├── main.tsx           # React DOM render entry
+│   │   ├── App.tsx            # Root component: onboarding gate, 4-tab nav
+│   │   ├── api.ts             # All API calls (typed fetch wrapper)
+│   │   ├── db.ts              # IndexedDB for offline sets and cached layouts
+│   │   ├── types.ts           # TypeScript interfaces (ChatResponse, PlannedSet, etc.)
+│   │   ├── index.css          # Global styles
+│   │   ├── screens/           # Full-page views (10 files)
+│   │   │   ├── workout.tsx    # Primary chat + workout screen (state A/B/C pattern)
+│   │   │   ├── workout-home.tsx # Day list for browsing chat history
+│   │   │   ├── workout-session.tsx # Layout-driven workout session
+│   │   │   ├── coach.tsx      # Standalone chat (legacy/alternate)
+│   │   │   ├── dashboard.tsx  # Layout-driven dashboard with offline fallback
+│   │   │   ├── history.tsx    # Workout history + program tabs
+│   │   │   ├── diet.tsx       # Meal tracking and nutrition view
+│   │   │   ├── profile.tsx    # User profile + Whoop settings
+│   │   │   ├── program.tsx    # Program week view
+│   │   │   └── progress.tsx   # Charts (e1RM, volume, Whoop trends)
+│   │   ├── components/        # Reusable UI components (26 files)
+│   │   │   ├── layout-renderer.tsx  # Maps Claude's layout JSON to React components
+│   │   │   ├── chat-bubble.tsx      # Message display
+│   │   │   ├── set-card.tsx         # Active set tracking card
+│   │   │   ├── exercise-card.tsx    # Exercise display
+│   │   │   ├── context-banner.tsx   # Date/workout context display
+│   │   │   ├── recovery-banner.tsx  # Whoop recovery zone display
+│   │   │   ├── program-view.tsx     # Full program display
+│   │   │   ├── program-week.tsx     # Week-level program view
+│   │   │   ├── program-day.tsx      # Day-level program view
+│   │   │   ├── day-card.tsx         # Day summary card
+│   │   │   ├── onboarding.tsx       # Onboarding flow wrapper
+│   │   │   ├── coach-interview.tsx  # Multi-step interview component
+│   │   │   ├── intake.tsx           # Initial profile intake form
+│   │   │   ├── bottom-nav.tsx       # Tab navigation bar
+│   │   │   ├── header.tsx           # Layout component: header
+│   │   │   ├── stat-card.tsx        # Layout component: stat card
+│   │   │   ├── set-logger.tsx       # Layout component: set logger
+│   │   │   ├── rest-timer.tsx       # Layout component: rest timer
+│   │   │   ├── text-block.tsx       # Layout component: text block
+│   │   │   ├── action-button.tsx    # Layout component: action button
+│   │   │   ├── video-prompt.tsx     # Layout component: video prompt
+│   │   │   ├── chart.tsx            # Layout component: chart
+│   │   │   ├── mini-chart.tsx       # Small inline chart
+│   │   │   ├── nutrition-card.tsx   # Nutrition summary card
+│   │   │   ├── meal-card.tsx        # Individual meal display
+│   │   │   ├── workout-bar.tsx      # Workout progress bar
+│   │   │   ├── workout-detail.tsx   # Expanded workout view
+│   │   │   └── prs-tab.tsx          # Personal records tab
+│   │   └── hooks/             # Custom React hooks (3 files)
+│   │       ├── use-offline.ts # Online/offline detection + sync
+│   │       ├── use-voice.ts   # SpeechRecognition wrapper
+│   │       └── use-camera.ts  # Camera access (for video form checks)
+│   └── dist/                  # Built PWA (served by FastAPI in production)
+├── tests/                     # pytest suite (18 test files)
+│   ├── test_chat.py
+│   ├── test_workout.py
+│   ├── test_program.py
+│   ├── test_program_week.py
+│   ├── test_meals.py
+│   ├── test_meals_day.py
+│   ├── test_morning.py
+│   ├── test_progress.py
+│   ├── test_history_prs.py
+│   ├── test_layout.py
+│   ├── test_video.py
+│   ├── test_whoop.py
+│   ├── test_whoop_tools.py
+│   ├── test_claude_sdk.py
+│   ├── test_database.py
+│   ├── test_sequencer.py
+│   ├── test_complete_set.py
+│   ├── test_training_log.py
+│   ├── test_daily_chat.py
+│   └── test_utils.py
+├── alembic/                   # Database migrations
+│   ├── env.py
+│   └── versions/
+│       ├── fa1934893c73_add_training_log_table.py
+│       └── 002_whoop_v04.py
+├── deploy/                    # systemd service/timer files
+│   ├── spotme.service         # Main uvicorn server
+│   ├── spotme-morning.service # Morning briefing oneshot
+│   ├── spotme-morning.timer   # Triggers at 07:00
+│   ├── spotme-whoop-sync.service
+│   └── spotme-whoop-sync.timer # Every 4 hours
+├── docs/                      # Design docs and specs
+├── pyproject.toml             # Python project config, dependencies
+├── alembic.ini                # Alembic config
+├── CLAUDE.md                  # Project-level AI instructions
+└── .planning/                 # GSD planning artifacts
+    └── codebase/              # This analysis
+```
+
+## Directory Purposes
+
+**`server/routes/`:**
+- Purpose: HTTP endpoint handlers, request orchestration, side-effect processing
+- Contains: 11 FastAPI `APIRouter` modules, one per domain
+- Key files: `chat.py` is the most complex (~450 lines, handles all Claude response side effects), `workout.py` handles set CRUD and workout lifecycle
+- Pattern: Each file exports `router = APIRouter()`, registered in `server/main.py` with `/api` prefix
+
+**`server/services/`:**
+- Purpose: Business logic isolated from HTTP concerns
+- Contains: 7 service modules plus `__init__.py`
+- Key files: `claude_service.py` (Claude CLI integration, context assembly, tool loop), `whoop_service.py` (biometric sync, workout push, journal sync), `workout_sequencer.py` (set-by-set flow management)
+- Pattern: Mix of classes (`ClaudeService`, `VideoService`) and free functions. Services are stateless, instantiated per-request.
+
+**`frontend/src/screens/`:**
+- Purpose: Full-page views corresponding to app tabs/states
+- Contains: 10 screen components
+- Key files: `workout.tsx` is the primary user-facing screen (chat + workout combined, ~200 lines with 3 internal states: daily chat, day list, active workout)
+
+**`frontend/src/components/`:**
+- Purpose: Reusable UI primitives and layout components
+- Contains: 26 component files
+- Key files: `layout-renderer.tsx` (maps Claude's JSON layout descriptors to React components), `set-card.tsx` (active workout set tracking), `onboarding.tsx` (initial setup flow)
+
+**`frontend/src/hooks/`:**
+- Purpose: Shared React hooks for device capabilities
+- Contains: 3 hooks (offline sync, voice input, camera)
+
+**`tests/`:**
+- Purpose: pytest test suite for backend
+- Contains: 18 test files, no frontend tests
+- Pattern: Tests use `sqlite:///:memory:` with `StaticPool`, mock Claude via monkeypatch
+
+**`deploy/`:**
+- Purpose: systemd service and timer definitions for Steam Deck deployment
+- Contains: 5 files (1 main service, 2 service+timer pairs for morning briefing and whoop sync)
+
+**`alembic/`:**
+- Purpose: Database migration scripts
+- Contains: Migration runner config and 2 version files
+- Note: Most schema evolution happens via inline ALTER TABLE in `server/main.py::create_app()`, not via Alembic migrations
+
+## Key File Locations
+
+**Entry Points:**
+- `server/main.py`: FastAPI app factory and server entry (`app = create_app()`)
+- `frontend/src/main.tsx`: React DOM render
+- `frontend/src/App.tsx`: Root component (onboarding gate + tab router)
+- `server/cli.py`: CLI for background jobs
+- `server/scripts/morning_briefing.py`: Scheduled morning push
+
+**Configuration:**
+- `server/config.py`: `Settings` class (loads `.env`), `today_eastern()`, `TIMEZONE`
+- `pyproject.toml`: Python dependencies, build config, pytest config
+- `frontend/vite.config.ts`: Vite build config (not in source tree but referenced)
+- `alembic.ini`: Alembic migration config
+- `CLAUDE.md`: Project-level AI instructions (root)
+- `server/CLAUDE.md`: Backend-specific AI instructions
+
+**Core Logic:**
+- `server/services/claude_service.py`: Claude CLI invocation, context assembly, tool-use loop
+- `server/routes/chat.py`: Primary chat endpoint with all side-effect processing
+- `server/services/whoop_service.py`: Whoop API integration
+- `server/services/workout_sequencer.py`: Set-by-set workout management
+- `server/services/program_parser.py`: Training program markdown parser
+
+**Data Layer:**
+- `server/models.py`: All 13 SQLAlchemy models
+- `server/database.py`: Engine, sessions, per-user DB routing
+- `server/schemas.py`: Pydantic DTOs
+
+**Testing:**
+- `tests/test_chat.py`: Chat endpoint tests
+- `tests/test_sequencer.py`: Workout sequencer unit tests
+- `tests/test_training_log.py`: Training log feature tests
+
+## Naming Conventions
+
+**Files:**
+- Python: snake_case (`claude_service.py`, `whoop_tools.py`)
+- TypeScript: kebab-case (`layout-renderer.tsx`, `use-offline.ts`)
+- Test files: `test_{module}.py` in `tests/` directory
+
+**Directories:**
+- All lowercase, no separators (`routes`, `services`, `components`, `screens`, `hooks`)
+
+**Python modules:**
+- Route files export `router = APIRouter()`
+- Service files export classes or free functions
+- Models file contains all ORM classes in one file
+
+**React components:**
+- One component per file
+- PascalCase exports (`LayoutRenderer`, `ChatBubble`, `SetCard`)
+- kebab-case filenames matching component (`layout-renderer.tsx` -> `LayoutRenderer`)
+
+**API constants:**
+- `MEMORY_KEY = "training_plan"` in `server/routes/chat.py`
+- `CLAUDE_BIN`, `MODEL`, `SYSTEM_PROMPT`, `WHOOP_TOOLS`, `MAX_TOOL_ITERATIONS` in `server/services/claude_service.py`
+- `VALID_COMPONENT_TYPES` in `server/services/layout_service.py`
+
+## Where to Add New Code
+
+**New API Endpoint:**
+1. Create `server/routes/new_route.py` with `router = APIRouter()`
+2. Add request/response schemas to `server/schemas.py`
+3. Register in `server/main.py`: `app.include_router(router, prefix="/api")`
+4. Add tests in `tests/test_new_route.py`
+5. Add API method in `frontend/src/api.ts`
+
+**New Service/Business Logic:**
+- Create `server/services/new_service.py`
+- Import and use from route handlers
+- Keep services stateless -- instantiate per-request or use free functions
+
+**New Claude Tool (Whoop):**
+1. Add tool schema dict to `WHOOP_TOOLS` list in `server/services/claude_service.py`
+2. Add async handler function in `server/services/whoop_tools.py`
+3. Register in `TOOL_HANDLERS` dict in `server/services/whoop_tools.py`
+
+**New Layout Component:**
+1. Create `frontend/src/components/new-component.tsx`
+2. Add to `COMPONENT_MAP` in `frontend/src/components/layout-renderer.tsx`
+3. Add type string to `VALID_COMPONENT_TYPES` in `server/services/layout_service.py`
+4. Add to `ComponentType` union in `frontend/src/types.ts`
+
+**New Frontend Screen:**
+1. Create `frontend/src/screens/new-screen.tsx`
+2. Add to tab routing in `frontend/src/App.tsx`
+3. Add tab to `BottomNav` in `frontend/src/components/bottom-nav.tsx`
+
+**New React Hook:**
+- Create `frontend/src/hooks/use-new-hook.ts`
+- Export camelCase function (`useNewHook`)
+
+**New Database Table:**
+1. Add model class to `server/models.py`
+2. Add Alembic migration in `alembic/versions/` (or use inline ALTER TABLE in `server/main.py` for simple additions)
+3. `Base.metadata.create_all()` in `server/main.py::create_app()` handles initial creation
+
+**New Context Source for Claude:**
+- Add parameter to `assemble_context()` in `server/services/claude_service.py`
+- Add data gathering in `server/routes/chat.py::chat()` handler
+- Append formatted text to `parts` list in `assemble_context()`
+
+**New Claude Response Field (side effect):**
+1. Add field to `SYSTEM_PROMPT` JSON format documentation in `server/services/claude_service.py`
+2. Extract from `result` dict in `ClaudeService.chat()` return value
+3. Handle side effect in `server/routes/chat.py::chat()` after the Claude call
+4. Add to `ChatResponse` schema if it needs to reach the frontend
+
+## Special Directories
+
+**`.planning/`:**
+- Purpose: GSD planning and analysis artifacts
+- Generated: Yes (by Claude Code)
+- Committed: No (typically gitignored)
+
+**`frontend/dist/`:**
+- Purpose: Built PWA static files
+- Generated: Yes (`npm run build`)
+- Committed: No (gitignored)
+- Served: By FastAPI in production via `StaticFiles` mount
+
+**`deploy/`:**
+- Purpose: systemd unit files for Steam Deck deployment
+- Generated: No
+- Committed: Yes
+
+**`.venv/`:**
+- Purpose: Python virtual environment
+- Generated: Yes
+- Committed: No
+
+**`docs/superpowers/`:**
+- Purpose: Design specs and plans from AI-assisted planning sessions
+- Generated: Yes
+- Committed: Yes
+
+---
+
+*Structure analysis: 2026-03-23*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,393 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-03-23
+
+## Test Framework
+
+**Runner:**
+- pytest 9.0.2 with pytest-asyncio 1.3.0
+- Config: `pyproject.toml` `[tool.pytest.ini_options]`
+- Python 3.13.1
+
+**Assertion Library:**
+- Built-in `assert` statements (pytest rewrites)
+- No additional assertion library
+
+**Run Commands:**
+```bash
+cd /home/deck/spotme
+.venv/bin/python -m pytest tests/ -x --tb=short   # run all, stop on first failure
+.venv/bin/python -m pytest tests/test_chat.py -v   # single file
+.venv/bin/python -m pytest tests/ -v               # verbose all
+```
+
+**Configuration:**
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+```
+`asyncio_mode = "auto"` means async test functions are automatically detected -- no need for `@pytest.mark.asyncio` decorator, though it is still used throughout.
+
+## Test File Organization
+
+**Location:** Separate `tests/` directory at project root (not co-located with source).
+
+**Naming:** `test_{module}.py` where module maps to source:
+| Test File | Tests For |
+|-----------|-----------|
+| `tests/test_chat.py` | `server/services/claude_service.py` (assemble_context, ClaudeService.chat) + `server/routes/chat.py` helpers |
+| `tests/test_claude_sdk.py` | `server/services/claude_service.py` (_call_claude subprocess, _call_claude_with_tools) |
+| `tests/test_daily_chat.py` | `server/routes/chat.py` (daily chat day-scoped endpoints) |
+| `tests/test_training_log.py` | TrainingLog model, context assembly, chat route log entry saving |
+| `tests/test_layout.py` | `server/services/layout_service.py` (validate_layout) |
+| `tests/test_workout.py` | `server/routes/workout.py` (today, next, recent, exercise/last) |
+| `tests/test_complete_set.py` | `server/routes/workout.py` (complete-set endpoint) |
+| `tests/test_sequencer.py` | `server/services/workout_sequencer.py` (create_workout_from_plan, complete_set, get_next_set) |
+| `tests/test_whoop.py` | `server/services/whoop_service.py` (sync_biometrics, push_workout, queue, catalog) |
+| `tests/test_whoop_tools.py` | `server/services/whoop_tools.py` (execute_whoop_tool dispatch) |
+| `tests/test_morning.py` | `server/routes/morning.py` (morning briefing endpoint) |
+| `tests/test_program.py` | `server/routes/program.py` + `server/services/program_parser.py` |
+| `tests/test_program_week.py` | `server/routes/program.py` (/program/week endpoint) |
+| `tests/test_progress.py` | `server/routes/progress.py` (e1rm, volume, whoop trends) |
+| `tests/test_meals.py` | `server/routes/meals.py` (CRUD, totals) |
+| `tests/test_meals_day.py` | `server/routes/meals.py` (day-specific endpoint) |
+| `tests/test_history_prs.py` | `server/routes/workout.py` (recent) + `server/routes/progress.py` (PRs) |
+| `tests/test_database.py` | `server/models.py` (ORM model creation) |
+| `tests/test_video.py` | `server/services/video_service.py` (validation, ffmpeg command) |
+| `tests/test_utils.py` | `server/config.py` (today_eastern) + `server/utils.py` (recovery_zone) |
+
+**Test count:** 140 tests, all passing.
+
+**Structure:**
+```
+tests/
+├── __init__.py              # empty
+├── test_chat.py             # 18 tests (186 lines)
+├── test_claude_sdk.py       #  4 tests (94 lines)
+├── test_complete_set.py     #  4 tests (110 lines)
+├── test_daily_chat.py       #  7 tests (100 lines)
+├── test_database.py         #  4 tests (48 lines)
+├── test_history_prs.py      #  4 tests (128 lines)
+├── test_layout.py           #  5 tests (39 lines)
+├── test_meals.py            #  7 tests (117 lines)
+├── test_meals_day.py        #  4 tests (65 lines)
+├── test_morning.py          #  6 tests (126 lines)
+├── test_program.py          #  6 tests (197 lines)
+├── test_program_week.py     #  8 tests (192 lines)
+├── test_progress.py         #  5 tests (191 lines)
+├── test_sequencer.py        #  8 tests (135 lines)
+├── test_training_log.py     #  4 tests (141 lines)
+├── test_utils.py            #  6 tests (41 lines)
+├── test_video.py            #  4 tests (20 lines)
+├── test_whoop.py            # 18 tests (575 lines)
+└── test_whoop_tools.py      #  4 tests (70 lines)
+```
+
+## Database Fixture Patterns
+
+**Primary pattern -- in-memory SQLite with StaticPool:**
+```python
+@pytest.fixture
+def db():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(eng)
+    session = sessionmaker(bind=eng)()
+    yield session
+    session.close()
+```
+Used in: `test_chat.py`, `test_sequencer.py`, `test_meals.py`, `test_meals_day.py`, `test_whoop.py`
+
+**Route test pattern -- FastAPI TestClient with dependency override:**
+```python
+@pytest.fixture
+def client(db):
+    from server.main import create_app
+    app = create_app()
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+```
+Used in: `test_daily_chat.py`, `test_meals.py`, `test_meals_day.py`
+
+**Alternative route pattern -- _make_app_and_session factory:**
+```python
+def _make_app_and_session():
+    from server.main import create_app
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine)
+
+    def override_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app = create_app()
+    app.dependency_overrides[get_db] = override_db
+    return app, TestSession
+```
+Used in: `test_morning.py`, `test_workout.py`, `test_program.py`, `test_program_week.py`, `test_progress.py`, `test_history_prs.py`, `test_complete_set.py`
+
+**Seeded fixture pattern:**
+```python
+@pytest.fixture
+def seeded_db(db):
+    program = Program(name="Test", goal="test", phase="test")
+    db.add(program)
+    db.commit()
+    workout = Workout(program_id=program.id, ...)
+    db.add(workout)
+    db.commit()
+    # ... more seed data
+    return db
+```
+Used in: `test_whoop.py` for push_workout tests
+
+## Mocking Claude (Subprocess)
+
+**Pattern 1 -- Mock `_call_claude` at function level:**
+The most common pattern mocks the internal `_call_claude` function, bypassing the subprocess entirely. This tests `ClaudeService.chat()` JSON parsing and field extraction.
+
+```python
+# tests/test_chat.py
+@pytest.mark.asyncio
+async def test_chat_returns_text_and_layout():
+    with patch("server.services.claude_service._call_claude", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = '{"response": "Go heavy today", "layout": {"screen": "workout_session", "layout": [{"type": "header", "title": "Bench Day"}]}}'
+        service = ClaudeService()
+        result = await service.chat("what's my workout?", context="test context")
+        assert "Go heavy" in result["response"]
+        assert result["layout"]["screen"] == "workout_session"
+```
+
+**Pattern 2 -- Mock subprocess at asyncio level:**
+Tests `_call_claude` itself by mocking `asyncio.create_subprocess_exec` and `asyncio.wait_for`. This verifies CLI invocation, JSON extraction, and error handling.
+
+```python
+# tests/test_claude_sdk.py
+async def _mock_wait_for(coro, timeout):
+    """await the coroutine like real wait_for does."""
+    return await coro
+
+@pytest.mark.asyncio
+async def test_call_claude_returns_json_response():
+    from server.services.claude_service import _call_claude
+    proc = AsyncMock()
+    proc.communicate.return_value = (b'{"response": "test reply", "layout": null}', b"")
+    proc.returncode = 0
+    with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with patch("asyncio.wait_for", side_effect=_mock_wait_for):
+            result = await _call_claude("test system prompt", "hello")
+    assert "test reply" in result
+```
+
+**Pattern 3 -- Mock `ClaudeService` at route level:**
+For integration tests of the chat route, the entire `ClaudeService` class is mocked to control the full response dict.
+
+```python
+# tests/test_training_log.py
+def test_chat_saves_training_log_entry(test_app, engine):
+    with patch("server.routes.chat.ClaudeService") as MockService:
+        mock_instance = MagicMock()
+        MockService.return_value = mock_instance
+        mock_instance.chat = AsyncMock(return_value={
+            "response": "Nice work on pull day!",
+            "layout": None, "profile": None,
+            "memory_update": None, "set_suggestion": None,
+            "meal": None, "workout_plan": None,
+            "training_log_entry": {
+                "type": "completion",
+                "day": "Pull / Back",
+                "summary": "75 min, all exercises completed",
+            },
+        })
+        resp = test_app.post("/api/chat", json={"message": "just finished pull day"})
+    assert resp.status_code == 200
+```
+
+## Mocking Whoop
+
+**Pattern -- Mock `get_whoop_client` factory:**
+```python
+# tests/test_whoop.py
+@pytest.mark.asyncio
+async def test_sync_biometrics_happy_path(db):
+    mock_recovery = MagicMock()
+    mock_recovery.created_at = "2026-03-16T10:00:00Z"
+    mock_recovery.recovery_score = 85.0
+    mock_recovery.hrv = 72.5
+    mock_recovery.resting_hr = 50
+
+    mock_client = AsyncMock()
+    mock_client.get_recovery.return_value = [mock_recovery]
+    mock_client.get_sleep.return_value = [mock_sleep]
+    mock_client.get_cycles.return_value = [mock_cycle]
+
+    with patch("server.services.whoop_service.get_whoop_client") as mock_factory:
+        mock_factory.return_value = mock_client
+        result = await sync_whoop_biometrics(db, force=True)
+
+    assert result["synced"] == 1
+```
+
+**What to mock:**
+- Always mock `get_whoop_client` -- never call real Whoop API
+- Always mock `_call_claude` or `ClaudeService` -- never call real Claude
+- Mock `asyncio.create_subprocess_exec` when testing subprocess invocation
+
+**What NOT to mock:**
+- SQLAlchemy in-memory database (use real queries against `:memory:`)
+- `assemble_context()` (test directly with real arguments)
+- `validate_layout()` (pure function, test directly)
+- `create_workout_from_plan()` (test with real DB)
+- `program_parser.parse_program()` (pure function, test directly)
+
+## Test Data Patterns
+
+**Inline test data:**
+```python
+# tests/test_program.py
+SAMPLE_PLAN = """## Weekly Schedule
+- Friday: Pull / Back
+- Saturday: Legs
+- Sunday: Heavy Bench
+### Week 1 (Current)
+- Heavy (Sun 3/16): 255x3, 265x4, 225x6x3. COMPLETED on 56% recovery
+"""
+```
+
+**Workout seeding helper:**
+```python
+# tests/test_complete_set.py
+def _seed_workout(session):
+    w = Workout(date=today_eastern(), type="strength", status="active")
+    session.add(w)
+    session.flush()
+    ex = Exercise(workout_id=w.id, name="Bench Press", order=0)
+    session.add(ex)
+    session.flush()
+    sets = []
+    for i in range(3):
+        s = Set(exercise_id=ex.id, weight=225, reps=5, ...)
+        session.add(s)
+        session.flush()
+        sets.append(s.id)
+    session.commit()
+    return w.id, sets
+```
+
+**No shared fixtures file.** Each test file defines its own fixtures. This leads to fixture duplication (db fixture repeated in 8+ files).
+
+## Coverage
+
+**Requirements:** No coverage threshold enforced. No coverage tool configured in `pyproject.toml`.
+
+**View Coverage:**
+```bash
+.venv/bin/python -m pytest tests/ --cov=server --cov-report=term-missing
+```
+(Requires `pytest-cov` to be installed -- not currently in dev dependencies.)
+
+## Test Types
+
+**Unit Tests:**
+- Pure function tests: `test_layout.py`, `test_utils.py`, `test_video.py`
+- Service method tests with mocked externals: `test_chat.py` (assemble_context), `test_sequencer.py`
+- Subprocess mocking tests: `test_claude_sdk.py`
+
+**Integration Tests:**
+- Route endpoint tests via FastAPI `TestClient`: `test_daily_chat.py`, `test_workout.py`, `test_meals.py`, `test_morning.py`, `test_program.py`, `test_progress.py`, `test_complete_set.py`, `test_history_prs.py`
+- Database integration tests: `test_database.py`
+- Whoop service tests with mocked client: `test_whoop.py`
+
+**E2E Tests:**
+- Not used. No end-to-end test framework.
+
+**No test for:**
+- `server/routes/interview.py` (no `test_interview.py`)
+- `server/routes/profile.py` (no `test_profile.py`)
+- `server/services/notification_service.py` (no tests)
+- `server/cli.py` (no tests)
+- `server/main.py` middleware and SPA fallback (no tests)
+- `server/scripts/morning_briefing.py` (no tests)
+- Error paths in `_call_claude`: timeout killing process, `_extract_json` edge cases
+
+## Common Patterns
+
+**Async Testing:**
+```python
+@pytest.mark.asyncio
+async def test_async_function():
+    result = await some_async_function()
+    assert result["key"] == expected
+```
+Note: `@pytest.mark.asyncio` is used even though `asyncio_mode = "auto"` makes it redundant.
+
+**Error Testing:**
+```python
+@pytest.mark.asyncio
+async def test_call_claude_raises_on_cli_error():
+    proc = AsyncMock()
+    proc.communicate.return_value = (b"", b"auth failed")
+    proc.returncode = 1
+    with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with patch("asyncio.wait_for", side_effect=_mock_wait_for):
+            with pytest.raises(RuntimeError, match="claude cli failed"):
+                await _call_claude("sys", "msg")
+```
+
+**Route error testing:**
+```python
+def test_complete_nonexistent_set():
+    client, _ = _make_app()
+    resp = client.post("/api/workout/complete-set", json={
+        "set_id": 9999, "actual_weight": 225, "actual_reps": 5,
+    })
+    assert resp.status_code == 200
+    assert "error" in resp.json()
+```
+
+**Date-sensitive tests:**
+Tests that involve "today" queries use `today_eastern()` or `date.today().isoformat()` to seed data for the current date. This ensures queries that filter by today's date match correctly.
+
+## Test Suite Technical Debt
+
+**Duplicated db fixtures:**
+The `db` fixture (in-memory SQLite + StaticPool) is copy-pasted in at least 8 test files. Should be extracted to `tests/conftest.py`.
+
+**Duplicated `_make_app_and_session` factory:**
+The app factory helper is copy-pasted in 7 test files. Should be a shared fixture.
+
+**Inconsistent fixture patterns:**
+Two approaches coexist for route tests:
+1. `lambda: db` override (simpler, used in `test_meals.py`, `test_daily_chat.py`)
+2. `_make_app_and_session()` with generator override (more correct for session lifecycle)
+
+The `lambda: db` approach does not properly close sessions per-request, which could leak state between tests.
+
+**Missing test coverage for key areas:**
+- `server/routes/interview.py` -- no tests at all
+- `server/routes/profile.py` -- no tests at all
+- Chat route integration (the `/api/chat` endpoint with ClaudeService mock) -- only tested in `test_training_log.py` for specific fields
+- Claude timeout handling and process kill path
+- `_extract_json()` function edge cases
+- `generate_interview_questions()` in `ClaudeService`
+- `analyze_form()` in `ClaudeService`
+- Memory update guard (blocking memory_update when training_log_entry present) only has 1 test
+
+**No conftest.py:**
+`tests/conftest.py` does not exist. All fixtures are local to each test file, causing significant duplication.
+
+**No coverage enforcement:**
+`pytest-cov` is not in dev dependencies. No coverage thresholds configured.
+
+---
+
+*Testing analysis: 2026-03-23*

--- a/docs/superpowers/plans/2026-03-23-daily-session-architecture.md
+++ b/docs/superpowers/plans/2026-03-23-daily-session-architecture.md
@@ -1,0 +1,1014 @@
+# Daily Session Architecture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace per-message CLI subprocess spawning with a single daily session that persists conversation state, streams responses, and handles tool-use in 2 calls.
+
+**Architecture:** Claude CLI sessions (`--session-id`, `--resume`) provide conversation continuity without persistent processes. One session per day, stored as a UUID in the DB. Daily handoff summarizes the old session into a TrainingLog entry before replacing it. Streaming uses `--output-format stream-json --verbose`, piped as SSE to the frontend.
+
+**Tech Stack:** Python/FastAPI (backend), Claude CLI 2.1.81 (`--print`, `--resume`, `--session-id`, `--output-format stream-json`), React 19/TypeScript (frontend SSE consumer)
+
+**Spec:** `docs/superpowers/specs/2026-03-23-daily-session-architecture-design.md`
+
+---
+
+## Task 1: Session Manager — create and resume daily sessions
+
+**Files:**
+- Create: `server/services/session_manager.py`
+- Modify: `server/config.py:21-22`
+- Test: `tests/test_session_manager.py`
+
+This is the core new module. It manages session lifecycle: create, resume, handoff, recover.
+
+- [ ] **Step 1: Add rollover config**
+
+In `server/config.py`, add after line 22:
+
+```python
+SESSION_ROLLOVER_HOUR = 4
+```
+
+- [ ] **Step 2: Write failing tests for session manager**
+
+Create `tests/test_session_manager.py`:
+
+```python
+import json
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from server.database import Base
+from server.models import SystemMemory
+from server.services.session_manager import SessionManager
+
+def _make_db():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+def test_get_session_creates_new_when_none_exists():
+    db = _make_db()
+    mgr = SessionManager()
+    session_id = mgr.get_or_create_session_id(db, "2026-03-23")
+    assert session_id is not None
+    # stored in DB
+    row = db.query(SystemMemory).filter_by(key="active_session").first()
+    assert row is not None
+    data = json.loads(row.content)
+    assert data["session_id"] == session_id
+    assert data["date"] == "2026-03-23"
+
+def test_get_session_reuses_existing_same_day():
+    db = _make_db()
+    mgr = SessionManager()
+    id1 = mgr.get_or_create_session_id(db, "2026-03-23")
+    id2 = mgr.get_or_create_session_id(db, "2026-03-23")
+    assert id1 == id2
+
+def test_get_session_creates_new_on_new_day():
+    db = _make_db()
+    mgr = SessionManager()
+    old_id = mgr.get_or_create_session_id(db, "2026-03-22")
+    new_id = mgr.get_or_create_session_id(db, "2026-03-23")
+    assert old_id != new_id
+    row = db.query(SystemMemory).filter_by(key="active_session").first()
+    data = json.loads(row.content)
+    assert data["date"] == "2026-03-23"
+
+def test_is_first_message_of_day():
+    db = _make_db()
+    mgr = SessionManager()
+    assert mgr.is_first_message(db, "2026-03-23") is True
+    mgr.get_or_create_session_id(db, "2026-03-23")
+    assert mgr.is_first_message(db, "2026-03-23") is False
+
+def test_needs_handoff():
+    db = _make_db()
+    mgr = SessionManager()
+    mgr.get_or_create_session_id(db, "2026-03-22")
+    assert mgr.needs_handoff(db, "2026-03-23") is True
+    assert mgr.needs_handoff(db, "2026-03-22") is False
+
+def test_invalidate_session():
+    db = _make_db()
+    mgr = SessionManager()
+    mgr.get_or_create_session_id(db, "2026-03-23")
+    mgr.invalidate_session(db)
+    assert mgr.is_first_message(db, "2026-03-23") is True
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pytest tests/test_session_manager.py -v`
+Expected: FAIL (module doesn't exist yet)
+
+- [ ] **Step 4: Implement session manager**
+
+Create `server/services/session_manager.py`:
+
+```python
+import json
+import logging
+import os
+import uuid
+
+from server.models import SystemMemory
+
+logger = logging.getLogger(__name__)
+
+SESSION_KEY = "active_session"
+SESSIONS_DIR = os.path.expanduser("~/.claude/projects/-home-deck-spotme")
+
+
+class SessionManager:
+
+    def get_or_create_session_id(self, db, today: str) -> str:
+        row = db.query(SystemMemory).filter_by(key=SESSION_KEY).first()
+        if row and row.content:
+            data = json.loads(row.content)
+            if data.get("date") == today:
+                return data["session_id"]
+            # new day — delete old session file, create new
+            self._delete_session_file(data.get("session_id"))
+
+        new_id = str(uuid.uuid4())
+        payload = json.dumps({"session_id": new_id, "date": today})
+        if row:
+            row.content = payload
+        else:
+            db.add(SystemMemory(key=SESSION_KEY, content=payload))
+        db.commit()
+        return new_id
+
+    def is_first_message(self, db, today: str) -> bool:
+        row = db.query(SystemMemory).filter_by(key=SESSION_KEY).first()
+        if not row or not row.content:
+            return True
+        data = json.loads(row.content)
+        return data.get("date") != today
+
+    def needs_handoff(self, db, today: str) -> bool:
+        row = db.query(SystemMemory).filter_by(key=SESSION_KEY).first()
+        if not row or not row.content:
+            return False
+        data = json.loads(row.content)
+        return data.get("date") != today and data.get("session_id") is not None
+
+    def get_old_session(self, db) -> tuple[str | None, str | None]:
+        """return (session_id, date) of the old session, or (None, None)"""
+        row = db.query(SystemMemory).filter_by(key=SESSION_KEY).first()
+        if not row or not row.content:
+            return None, None
+        data = json.loads(row.content)
+        return data.get("session_id"), data.get("date")
+
+    def invalidate_session(self, db):
+        row = db.query(SystemMemory).filter_by(key=SESSION_KEY).first()
+        if row:
+            if row.content:
+                data = json.loads(row.content)
+                self._delete_session_file(data.get("session_id"))
+            db.delete(row)
+            db.commit()
+
+    def _delete_session_file(self, session_id: str | None):
+        if not session_id:
+            return
+        path = os.path.join(SESSIONS_DIR, f"{session_id}.jsonl")
+        try:
+            os.remove(path)
+            logger.info("deleted session file: %s", path)
+        except FileNotFoundError:
+            pass
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_session_manager.py -v`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/services/session_manager.py tests/test_session_manager.py server/config.py
+git commit -m "feat: add session manager for daily Claude CLI sessions"
+```
+
+---
+
+## Task 2: Session-aware Claude calls — replace `_call_claude` for chat
+
+**Files:**
+- Modify: `server/services/claude_service.py:396-468`
+- Test: `tests/test_session_calls.py`
+
+Replace `_call_claude()` (used by chat) with session-aware versions. Keep the old `_call_claude()` renamed to `_call_claude_stateless()` for interview/form analysis.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_session_calls.py`:
+
+```python
+import asyncio
+import json
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from server.services.claude_service import (
+    _call_claude_session,
+    _call_claude_stateless,
+    _session_lock,
+)
+
+@pytest.fixture
+def mock_subprocess():
+    """mock asyncio.create_subprocess_exec to return a fake process"""
+    proc = AsyncMock()
+    proc.returncode = 0
+    proc.communicate = AsyncMock(return_value=(
+        json.dumps({"response": "test reply"}).encode(),
+        b"",
+    ))
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+    return proc
+
+@pytest.mark.asyncio
+async def test_session_call_uses_resume(mock_subprocess):
+    with patch("asyncio.create_subprocess_exec", return_value=mock_subprocess) as mock_exec:
+        result = await _call_claude_session(
+            session_id="abc-123",
+            message="hello",
+            is_first=False,
+        )
+        args = mock_exec.call_args[0]
+        assert "--resume" in args
+        assert "abc-123" in args
+        assert "--session-id" not in args
+
+@pytest.mark.asyncio
+async def test_session_call_uses_session_id_for_first(mock_subprocess):
+    with patch("asyncio.create_subprocess_exec", return_value=mock_subprocess) as mock_exec:
+        result = await _call_claude_session(
+            session_id="abc-123",
+            message="hello",
+            is_first=True,
+            system_prompt="you are a coach",
+        )
+        args = mock_exec.call_args[0]
+        assert "--session-id" in args
+        assert "abc-123" in args
+        assert "--append-system-prompt" in args
+
+@pytest.mark.asyncio
+async def test_stateless_call_uses_no_session_persistence(mock_subprocess):
+    with patch("asyncio.create_subprocess_exec", return_value=mock_subprocess) as mock_exec:
+        result = await _call_claude_stateless("system", "message")
+        args = mock_exec.call_args[0]
+        assert "--no-session-persistence" in args
+        assert "--resume" not in args
+
+@pytest.mark.asyncio
+async def test_session_lock_prevents_concurrent_calls(mock_subprocess):
+    """two calls should serialize, not run in parallel"""
+    call_order = []
+
+    async def slow_communicate():
+        call_order.append("start")
+        await asyncio.sleep(0.1)
+        call_order.append("end")
+        return (json.dumps({"response": "ok"}).encode(), b"")
+
+    mock_subprocess.communicate = slow_communicate
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_subprocess):
+        await asyncio.gather(
+            _call_claude_session("id", "msg1", is_first=False),
+            _call_claude_session("id", "msg2", is_first=False),
+        )
+
+    # should be start,end,start,end (serial) not start,start,end,end (parallel)
+    assert call_order == ["start", "end", "start", "end"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_session_calls.py -v`
+Expected: FAIL (functions don't exist yet)
+
+- [ ] **Step 3: Implement session-aware call functions**
+
+In `server/services/claude_service.py`, replace the `_call_claude` function (lines 396-417) and `_call_claude_with_tools` function (lines 420-468) with:
+
+```python
+_session_lock = asyncio.Lock()
+
+
+async def _call_claude_session(
+    session_id: str,
+    message: str,
+    is_first: bool = False,
+    system_prompt: str | None = None,
+) -> str:
+    """call claude within a persistent daily session."""
+    async with _session_lock:
+        args = [CLAUDE_BIN, "--print", "--tools", ""]
+        if is_first:
+            args.extend(["--session-id", session_id, "--model", MODEL])
+            if system_prompt:
+                args.extend(["--append-system-prompt", system_prompt])
+        else:
+            args.extend(["--resume", session_id])
+        args.extend(["-p", message])
+
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise RuntimeError("claude cli timed out after 120s")
+        if proc.returncode != 0:
+            error = stderr.decode().strip()
+            logger.error("claude session error: %s", error)
+            raise RuntimeError(f"claude cli failed: {error}")
+        raw = stdout.decode().strip()
+        return _extract_json(raw)
+
+
+async def _call_claude_stateless(system_prompt: str, message: str) -> str:
+    """call claude without session persistence (for one-off calls like interview questions)."""
+    proc = await asyncio.create_subprocess_exec(
+        CLAUDE_BIN, "--print",
+        "--no-session-persistence",
+        "--model", MODEL,
+        "--tools", "",
+        "--append-system-prompt", system_prompt,
+        "-p", message,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        raise RuntimeError("claude cli timed out after 120s")
+    if proc.returncode != 0:
+        error = stderr.decode().strip()
+        logger.error("claude cli error: %s", error)
+        raise RuntimeError(f"claude cli failed: {error}")
+    raw = stdout.decode().strip()
+    return _extract_json(raw)
+```
+
+Also update `generate_interview_questions` (line 348) and `analyze_form` (line 375) to call `_call_claude_stateless` instead of `_call_claude`.
+
+Remove the old `_call_claude` function (lines 396-417) and `_call_claude_with_tools` function (lines 420-468), and `MAX_TOOL_ITERATIONS` (line 420).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_session_calls.py tests/test_claude_sdk.py -v`
+Expected: session tests PASS. Existing claude tests may need updating for renamed function.
+
+- [ ] **Step 5: Fix broken existing tests**
+
+In `tests/test_claude_sdk.py`:
+- Rename all `_call_claude` imports/references to `_call_claude_stateless`
+- Delete the `test_tool_use_loop_executes_tool` test (and any other `_call_claude_with_tools` tests) — tool-use is now handled by the 2-call session pattern in `ClaudeService.chat()`
+- Verify: `pytest tests/test_claude_sdk.py -v` passes
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/services/claude_service.py tests/test_session_calls.py tests/test_claude_sdk.py
+git commit -m "feat: add session-aware and stateless Claude CLI call functions"
+```
+
+---
+
+## Task 3: Rewrite chat route to use sessions + 2-call tool pattern
+
+**Files:**
+- Modify: `server/routes/chat.py:82-280`
+- Modify: `server/services/claude_service.py` (ClaudeService.chat method, lines 298-335)
+- Test: `tests/test_chat_session.py`
+
+The chat route now: gets/creates the daily session, sends the message via `_call_claude_session`, handles tool-use with a follow-up `--resume` call, and processes side effects.
+
+- [ ] **Step 1: Write failing test for session-based chat**
+
+Create `tests/test_chat_session.py`:
+
+```python
+import json
+import pytest
+from unittest.mock import patch, AsyncMock
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from server.database import Base, get_db
+from server.models import SystemMemory, UserProfile, Conversation
+from server.config import today_eastern
+
+def _make_app():
+    from server.main import create_app
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine)
+    def override():
+        db = TestSession()
+        try: yield db
+        finally: db.close()
+    app = create_app()
+    app.dependency_overrides[get_db] = override
+    return TestClient(app), TestSession
+
+def test_chat_creates_session_on_first_message():
+    client, TestSession = _make_app()
+    db = TestSession()
+    db.add(UserProfile(name="Test"))
+    db.commit()
+    db.close()
+
+    mock_response = json.dumps({"response": "Hey! Ready to train.", "layout": None})
+    with patch("server.services.claude_service._call_claude_session", new_callable=AsyncMock, return_value=mock_response):
+        resp = client.post("/api/chat", json={"message": "hi", "workout_id": None, "date": None})
+    assert resp.status_code == 200
+
+    db = TestSession()
+    session_row = db.query(SystemMemory).filter_by(key="active_session").first()
+    assert session_row is not None
+    data = json.loads(session_row.content)
+    assert data["date"] == today_eastern()
+    db.close()
+
+def test_chat_resumes_existing_session():
+    client, TestSession = _make_app()
+    db = TestSession()
+    db.add(UserProfile(name="Test"))
+    db.add(SystemMemory(key="active_session", content=json.dumps({"session_id": "existing-uuid", "date": today_eastern()})))
+    db.commit()
+    db.close()
+
+    mock_response = json.dumps({"response": "Welcome back.", "layout": None})
+    with patch("server.services.claude_service._call_claude_session", new_callable=AsyncMock, return_value=mock_response) as mock_call:
+        resp = client.post("/api/chat", json={"message": "hey", "workout_id": None, "date": None})
+    assert resp.status_code == 200
+    # should have used resume (is_first=False)
+    _, kwargs = mock_call.call_args
+    assert kwargs.get("is_first") is False
+    assert kwargs.get("session_id") == "existing-uuid"
+
+def test_chat_tool_calls_execute_and_followup():
+    client, TestSession = _make_app()
+    db = TestSession()
+    db.add(UserProfile(name="Test"))
+    db.add(SystemMemory(key="active_session", content=json.dumps({"session_id": "tool-uuid", "date": today_eastern()})))
+    # seed a WhoopToken so the tool-use path is triggered
+    from server.models import WhoopToken
+    db.add(WhoopToken(access_token="fake", refresh_token="fake", user_id="1"))
+    db.commit()
+    db.close()
+
+    # first call returns tool_calls, second returns final response
+    call_count = 0
+    async def mock_session_call(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return json.dumps({"response": "Logging your sauna.", "tool_calls": [{"name": "create_whoop_activity", "arguments": {"activity_type": "sauna", "duration_minutes": 20}}]})
+        return json.dumps({"response": "Done — 20 min sauna logged."})
+
+    with patch("server.services.claude_service._call_claude_session", side_effect=mock_session_call):
+        with patch("server.services.whoop_tools.execute_whoop_tool", new_callable=AsyncMock, return_value={"success": True}):
+            resp = client.post("/api/chat", json={"message": "log my 20 min sauna", "workout_id": None, "date": None})
+
+    assert resp.status_code == 200
+    assert call_count == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_chat_session.py -v`
+Expected: FAIL
+
+- [ ] **Step 3: Rewrite ClaudeService.chat() to use sessions**
+
+In `server/services/claude_service.py`, replace the `ClaudeService.chat()` method (lines 298-335) with:
+
+```python
+class ClaudeService:
+
+    def __init__(self):
+        from server.services.session_manager import SessionManager
+        self.session_mgr = SessionManager()
+
+    async def chat(self, message: str, context: str, db=None, date: str | None = None) -> dict:
+        from server.config import today_eastern
+        today = date or today_eastern()
+
+        is_first = self.session_mgr.is_first_message(db, today)
+
+        # daily handoff: summarize old session before creating new
+        if self.session_mgr.needs_handoff(db, today):
+            await self._do_handoff(db, today)
+
+        session_id = self.session_mgr.get_or_create_session_id(db, today)
+
+        try:
+            if is_first:
+                # first message: system prompt in --append-system-prompt, context + user msg in -p
+                raw_text = await _call_claude_session(
+                    session_id=session_id,
+                    message=f"Current context:\n{context}\n\n{message}",
+                    is_first=True,
+                    system_prompt=SYSTEM_PROMPT,
+                )
+            else:
+                raw_text = await _call_claude_session(
+                    session_id=session_id,
+                    message=message,
+                    is_first=False,
+                )
+        except Exception as e:
+            logger.error("claude session call failed: %s", e)
+            # try recovery: invalidate and retry as fresh session
+            self.session_mgr.invalidate_session(db)
+            try:
+                session_id = self.session_mgr.get_or_create_session_id(db, today)
+                full_message = f"{context}\n\n{message}"
+                raw_text = await _call_claude_session(
+                    session_id=session_id,
+                    message=full_message,
+                    is_first=True,
+                    system_prompt=system,
+                )
+            except Exception as e2:
+                logger.error("claude recovery failed: %s", e2)
+                return self._error_response()
+
+        # parse response
+        try:
+            parsed = json.loads(raw_text)
+        except json.JSONDecodeError:
+            return {"response": raw_text, "layout": None, "profile": None, "memory_update": None, "training_log_entry": None, "set_suggestion": None, "meal": None, "workout_plan": None}
+
+        # handle tool calls — 2nd call within the same session
+        tool_calls = parsed.get("tool_calls", [])
+        if tool_calls and db:
+            from server.services.whoop_tools import execute_whoop_tool
+            results = []
+            for tc in tool_calls:
+                result = await execute_whoop_tool(tc["name"], tc.get("arguments", {}), db)
+                results.append({"tool": tc["name"], "result": result})
+            # follow-up in same session with tool results
+            try:
+                followup_text = await _call_claude_session(
+                    session_id=session_id,
+                    message=f"Tool results: {json.dumps(results)}",
+                    is_first=False,
+                )
+                try:
+                    parsed = json.loads(followup_text)
+                except json.JSONDecodeError:
+                    parsed["response"] = followup_text
+
+            except Exception:
+                # tool followup failed — use the initial response
+                pass
+
+        layout = parsed.get("layout")
+        if layout:
+            validation = validate_layout(layout)
+            layout = validation["layout"] if validation["valid"] else None
+
+        return {
+            "response": parsed.get("response", raw_text),
+            "layout": layout,
+            "profile": parsed.get("profile"),
+            "memory_update": parsed.get("memory_update"),
+            "training_log_entry": parsed.get("training_log_entry"),
+            "set_suggestion": parsed.get("set_suggestion"),
+            "meal": parsed.get("meal"),
+            "workout_plan": parsed.get("workout_plan"),
+        }
+
+    _handoff_lock = asyncio.Lock()
+
+    async def _do_handoff(self, db, today: str):
+        """summarize old session and create new one"""
+        async with self._handoff_lock:
+            if not self.session_mgr.needs_handoff(db, today):
+                return  # another concurrent call already did it
+            old_id, old_date = self.session_mgr.get_old_session(db)
+            if not old_id:
+                return
+            try:
+                summary_text = await _call_claude_session(
+                    session_id=old_id,
+                    message="Summarize today's coaching session in 2-3 sentences. Include: what was trained, key performance notes, any program adjustments discussed, and anything to carry forward to tomorrow.",
+                    is_first=False,
+                )
+                # extract the response text from JSON (not the raw JSON blob)
+                try:
+                    parsed = json.loads(summary_text)
+                    summary_content = parsed.get("response", summary_text)
+                except json.JSONDecodeError:
+                    summary_content = summary_text
+                from server.models import TrainingLog
+                db.add(TrainingLog(
+                    date=old_date or today,
+                    log_type="daily_summary",
+                    content=summary_content[:500],
+                ))
+                db.commit()
+            except Exception as e:
+                logger.warning("session handoff summary failed: %s", e)
+            # invalidate old session (deletes file)
+            self.session_mgr.invalidate_session(db)
+
+    def _error_response(self):
+        return {"response": "Having trouble reaching Claude right now. Try again in a sec.", "layout": None, "profile": None, "memory_update": None, "training_log_entry": None, "set_suggestion": None, "meal": None, "workout_plan": None}
+```
+
+- [ ] **Step 4: Update chat route to pass `date` to service**
+
+In `server/routes/chat.py` line 171, change:
+```python
+result = await service.chat(request.message, context, db=db)
+```
+to:
+```python
+result = await service.chat(request.message, context, db=db, date=request_date)
+```
+
+- [ ] **Step 5: Unblock concurrent memory_update + training_log_entry**
+
+In `server/routes/chat.py` line 198, change:
+```python
+if memory_update and isinstance(memory_update, str) and not log_entry:
+```
+to:
+```python
+if memory_update and isinstance(memory_update, str):
+    # safety: reject if update is >50% shorter (accidental truncation)
+    if memory_row and len(memory_update) < len(memory_row.content or "") * 0.5:
+        logger.warning("blocked memory_update: %d chars vs existing %d chars", len(memory_update), len(memory_row.content or ""))
+    elif memory_row:
+```
+Preserve the existing `else` branch for creating new memory.
+
+- [ ] **Step 6: Run tests**
+
+Run: `pytest tests/test_chat_session.py tests/test_chat.py -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/services/claude_service.py server/routes/chat.py tests/test_chat_session.py
+git commit -m "feat: rewrite chat to use daily session with 2-call tool pattern"
+```
+
+---
+
+## Task 4: Frontend streaming — receive SSE and render tokens incrementally
+
+**Files:**
+- Modify: `frontend/src/api.ts:17`
+- Modify: `frontend/src/screens/workout.tsx:86-105`
+- Create: `server/routes/chat_stream.py`
+- Modify: `server/main.py` (register new router)
+
+- [ ] **Step 1: Create SSE streaming endpoint**
+
+Create `server/routes/chat_stream.py`:
+
+```python
+import asyncio
+import json
+import logging
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+from server.database import get_db
+from server.services.claude_service import CLAUDE_BIN, MODEL, SYSTEM_PROMPT, _session_lock, _extract_json, assemble_context
+from server.services.session_manager import SessionManager
+from server.models import SystemMemory, Conversation, UserProfile, WhoopData, Meal, Workout, Exercise, Set
+from server.config import today_eastern
+from sqlalchemy import func as sqlfunc
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+session_mgr = SessionManager()
+
+from server.schemas import ChatRequest
+
+@router.post("/chat/stream")
+async def stream_chat(request: ChatRequest, db: Session = Depends(get_db)):
+    """SSE endpoint that streams Claude's response token by token"""
+    message = request.message
+    request_date = request.date or today_eastern()
+
+    # build context (same as chat route)
+    profile = db.query(UserProfile).first()
+    profile_dict = {"name": profile.name, "goals": profile.goals, "experience_level": profile.experience_level, "equipment": profile.equipment, "training_frequency": profile.training_frequency, "injuries_notes": profile.injuries_notes, "calorie_target": profile.calorie_target, "protein_target": profile.protein_target} if profile else None
+    whoop_dict = None
+    whoop = db.query(WhoopData).filter_by(date=today_eastern()).first()
+    if whoop:
+        whoop_dict = {"recovery_score": whoop.recovery_score, "hrv": whoop.hrv, "resting_hr": whoop.resting_hr, "sleep_score": whoop.sleep_score, "sleep_duration": whoop.sleep_duration, "strain": whoop.strain}
+    memory_row = db.query(SystemMemory).filter_by(key="training_plan").first()
+    memory_text = memory_row.content if memory_row else None
+    from server.models import TrainingLog
+    recent_logs = db.query(TrainingLog).order_by(TrainingLog.id.desc()).limit(15).all()
+    training_log_dicts = [{"date": log.date, "type": log.log_type, "content": log.content} for log in reversed(recent_logs)]
+    context = assemble_context(None, None, whoop_dict, [], profile_dict, memory_text, training_log=training_log_dicts, db=db)
+
+    is_first = session_mgr.is_first_message(db, request_date)
+    if session_mgr.needs_handoff(db, request_date):
+        from server.services.claude_service import ClaudeService
+        svc = ClaudeService()
+        await svc._do_handoff(db, request_date)
+
+    session_id = session_mgr.get_or_create_session_id(db, request_date)
+    system = f"{SYSTEM_PROMPT}\n\nCurrent context:\n{context}"
+
+    args = [CLAUDE_BIN, "--print", "--output-format", "stream-json", "--verbose", "--tools", ""]
+    if is_first:
+        args.extend(["--session-id", session_id, "--model", MODEL, "--append-system-prompt", system])
+        msg = f"{context}\n\n{message}"
+    else:
+        args.extend(["--resume", session_id])
+        msg = message
+    args.extend(["-p", msg])
+
+    async def event_stream():
+        # acquire lock only to start the process, then release
+        async with _session_lock:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        # stream outside the lock — session file is safe once the process has started
+        full_text = ""
+        try:
+            async for line in proc.stdout:
+                decoded = line.decode().strip()
+                if not decoded:
+                    continue
+                try:
+                    event = json.loads(decoded)
+                except json.JSONDecodeError:
+                    continue
+                if event.get("type") == "assistant":
+                    content = event.get("message", {}).get("content", [])
+                    for block in content:
+                        if block.get("type") == "text":
+                            text = block["text"]
+                            full_text += text
+                            yield f"data: {json.dumps({'text': text})}\n\n"
+            await proc.wait()
+        except Exception as e:
+            logger.error("stream error: %s", e)
+            proc.kill()
+            await proc.wait()
+
+        # save conversation
+        db.add(Conversation(role="user", content=message, context_type="chat", date=request_date))
+        db.add(Conversation(role="assistant", content=full_text, context_type="chat", date=request_date))
+        db.commit()
+
+        yield f"data: {json.dumps({'done': True})}\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
+```
+
+- [ ] **Step 2: Register the streaming router in main.py**
+
+In `server/main.py`, add:
+```python
+from server.routes.chat_stream import router as chat_stream_router
+app.include_router(chat_stream_router, prefix="/api")
+```
+
+- [ ] **Step 3: Add `chatStream()` to frontend API**
+
+In `frontend/src/api.ts`, add after the `chat` method:
+
+```typescript
+chatStream: async (message: string, date?: string, onToken?: (text: string) => void): Promise<string> => {
+  const resp = await fetch(`${BASE}/chat/stream`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message, workout_id: null, date: date ?? null }),
+  })
+  if (!resp.ok) throw new Error(`API error: ${resp.status}`)
+  const reader = resp.body!.getReader()
+  const decoder = new TextDecoder()
+  let full = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    const chunk = decoder.decode(value, { stream: true })
+    for (const line of chunk.split('\n')) {
+      if (!line.startsWith('data: ')) continue
+      try {
+        const data = JSON.parse(line.slice(6))
+        if (data.done) return full
+        if (data.text) {
+          full += data.text
+          onToken?.(full)
+        }
+      } catch {}
+    }
+  }
+  return full
+},
+```
+
+- [ ] **Step 4: Update `send()` in workout.tsx to use streaming**
+
+In `frontend/src/screens/workout.tsx`, replace the `send` function (lines 86-105):
+
+```typescript
+const send = async (text: string) => {
+  if (!text.trim()) return
+  setMessages(m => [...m, { role: 'user', content: text }])
+  setInput('')
+  setThinking(true)
+  try {
+    const wid = workoutId && workoutId > 0 ? workoutId : undefined
+    if (wid) {
+      // active workout: use non-streaming (needs workout_id context)
+      const result = await api.chat(text, wid, wid ? undefined : chatDate)
+      setMessages(m => [...m, { role: 'assistant', content: result.response }])
+      if (result.workout_active && result.current_set) {
+        setWorkoutId(result.workout_id ?? null)
+        setCurrentSet(result.current_set)
+        setSetProgress({ completed: 0, total: 0, current_exercise_progress: '0 of 0' })
+      }
+    } else {
+      // daily chat: use streaming
+      setMessages(m => [...m, { role: 'assistant', content: '' }])
+      setThinking(false)
+      await api.chatStream(text, chatDate, (partial) => {
+        setMessages(m => {
+          const updated = [...m]
+          updated[updated.length - 1] = { role: 'assistant', content: partial }
+          return updated
+        })
+      })
+    }
+  } catch {
+    // recovery: try to load from server history
+    if (document.hidden) {
+      await new Promise<void>(resolve => {
+        const handler = () => { if (!document.hidden) { document.removeEventListener('visibilitychange', handler); resolve() } }
+        document.addEventListener('visibilitychange', handler)
+      })
+    }
+    try {
+      const history = await api.getChatDay(chatDate)
+      const msgs = history.messages.map(m => ({ role: m.role as 'user' | 'assistant', content: m.content }))
+      if (msgs.length > 0) { setMessages(msgs); return }
+    } catch {}
+    setMessages(m => [...m, { role: 'assistant', content: 'Connection error — try again in a sec.' }])
+  } finally {
+    setThinking(false)
+  }
+}
+```
+
+- [ ] **Step 5: Build and type-check frontend**
+
+Run: `cd frontend && npx tsc --noEmit && npm run build`
+Expected: no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/routes/chat_stream.py server/main.py frontend/src/api.ts frontend/src/screens/workout.tsx
+git commit -m "feat: add SSE streaming for chat responses"
+```
+
+---
+
+## Task 5: Cleanup — stale sessions, dead code, stale args
+
+**Files:**
+- Modify: `server/routes/video.py:20`
+- Modify: `server/routes/layout.py:19`
+- Run: cleanup script
+
+- [ ] **Step 1: Fix stale `api_key` arguments**
+
+In `server/routes/video.py` line 20, change:
+```python
+claude = ClaudeService(api_key=settings.anthropic_api_key)
+```
+to:
+```python
+claude = ClaudeService()
+```
+
+In `server/routes/layout.py` line 17-19, change:
+```python
+    if settings.anthropic_api_key:
+        try:
+            service = ClaudeService(api_key=settings.anthropic_api_key)
+```
+to:
+```python
+    try:
+        service = ClaudeService()
+```
+(Remove the `if settings.anthropic_api_key:` guard — ClaudeService now uses CLI OAuth, not an API key.)
+
+- [ ] **Step 2: Delete stale session files**
+
+```bash
+rm -f ~/.claude/projects/-home-deck-spotme/*.jsonl
+echo "deleted $(ls ~/.claude/projects/-home-deck-spotme/*.jsonl 2>/dev/null | wc -l) stale sessions"
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `pytest -x --tb=short`
+Expected: all tests PASS
+
+- [ ] **Step 4: Build frontend**
+
+Run: `cd frontend && npm run build`
+Expected: clean build
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/routes/video.py server/routes/layout.py
+git commit -m "fix: remove stale api_key args, clean up session files"
+```
+
+---
+
+## Task 6: Integration verification
+
+**Files:** None (testing only)
+
+- [ ] **Step 1: Restart service**
+
+```bash
+systemctl --user restart spotme
+```
+
+- [ ] **Step 2: Verify session creation**
+
+```bash
+# send a test message via curl
+curl -s -X POST http://localhost:8000/api/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"message": "hey", "workout_id": null, "date": null}' | python3 -m json.tool | head -5
+```
+
+Verify: only 1 session file in `~/.claude/projects/-home-deck-spotme/`
+
+- [ ] **Step 3: Verify session resumption**
+
+Send a second message and verify it reuses the same session:
+
+```bash
+curl -s -X POST http://localhost:8000/api/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"message": "what did I just say?", "workout_id": null, "date": null}' | python3 -m json.tool | head -5
+```
+
+Expected: Claude references the prior message. Still only 1 session file.
+
+- [ ] **Step 4: Verify streaming endpoint**
+
+```bash
+curl -N -X POST http://localhost:8000/api/chat/stream \
+  -H 'Content-Type: application/json' \
+  -d '{"message": "hello", "workout_id": null, "date": null}' 2>&1 | head -10
+```
+
+Expected: SSE events with `data: {"text": "..."}` lines.
+
+- [ ] **Step 5: Verify disk usage**
+
+```bash
+ls ~/.claude/projects/-home-deck-spotme/*.jsonl | wc -l
+du -sh ~/.claude/projects/-home-deck-spotme/
+```
+
+Expected: 1 file, <1MB

--- a/docs/superpowers/specs/2026-03-23-daily-session-architecture-design.md
+++ b/docs/superpowers/specs/2026-03-23-daily-session-architecture-design.md
@@ -1,0 +1,233 @@
+# Daily Session Architecture
+
+## Problem
+
+Every `/api/chat` request spawns a fresh `claude --print` subprocess (227MB binary, 2-5s startup, 100-200MB RAM). With Whoop tools connected, a single message spawns up to 3 sequential processes. Context (~4000 tokens) is rebuilt and re-sent on every call.
+
+Stale CLI sessions accumulate on disk: **211 session files (84MB)** in `~/.claude/projects/-home-deck-spotme/` alone, 587MB total across all projects. The current code uses `--print` without `--no-session-persistence`, so every API call creates a new session file that is never cleaned up.
+
+The app uses the Claude Code subscription (not an API key), so the Anthropic Python SDK is not an option. All Claude communication must go through the CLI.
+
+## Verified CLI Behaviors
+
+Tested on Claude CLI 2.1.81:
+
+| Flag combo | Behavior | Verified |
+|-----------|----------|----------|
+| `--print --session-id <uuid> -p "msg"` | Creates a session with known UUID, saves to disk | Yes |
+| `--print --resume <uuid> -p "msg"` | Resumes session, Claude remembers prior messages | Yes |
+| `--print --no-session-persistence -p "msg"` | Responds without saving session file | Yes |
+| `--output-format stream-json --verbose --print` | Streams JSONL events (requires `--verbose`) | Yes |
+| `--tools ""` | Disables all built-in tools (we handle tools ourselves) | Yes |
+| `--bare` | Skips hooks, LSP, auto-memory, CLAUDE.md — but breaks OAuth | Yes (unusable) |
+
+Session files live at: `~/.claude/projects/-home-deck-spotme/<uuid>.jsonl`
+No `sessions rm` CLI command exists — cleanup must delete files directly.
+
+## Design
+
+### One session per day
+
+A single Claude CLI session per day. The session ID (a UUID) and its creation date are stored in `SystemMemory(key="active_session")` as JSON.
+
+**First message of the day:**
+```bash
+claude --print \
+  --session-id <new-uuid> \
+  --tools "" \
+  --model claude-sonnet-4-20250514 \
+  --append-system-prompt "$SYSTEM_PROMPT" \
+  -p "$CONTEXT_BLOCK\n\n$USER_MESSAGE"
+```
+Creates a persistent session with full context (system prompt, training plan, whoop data, profile, last 15 training log entries including yesterday's daily summary, today's meals).
+
+**Subsequent messages:**
+```bash
+claude --print \
+  --resume <session-uuid> \
+  --tools "" \
+  -p "$USER_MESSAGE"
+```
+Resumes the session. Only the new user message is sent — Claude already has context from the session. If whoop data or meal totals changed since the last message, prepend a brief update.
+
+**No persistent processes**: each CLI invocation exits after responding. Session state lives on disk as a JSONL file managed by the CLI.
+
+### Daily handoff
+
+Triggered on the first message after 4 AM Eastern when a session from a previous day exists.
+
+1. Resume the old session with a summary prompt:
+   ```
+   claude --print --resume <old-uuid> --tools "" \
+     -p "Summarize today's coaching session in 2-3 sentences. Include: what was trained, key performance notes, any program adjustments discussed, and anything to carry forward to tomorrow."
+   ```
+2. Save the summary as a `TrainingLog` entry with `log_type="daily_summary"`.
+3. Delete the old session file: `rm ~/.claude/projects/-home-deck-spotme/<old-uuid>.jsonl`
+4. Create a new session with fresh context (which now includes the summary in the last 15 log entries).
+5. Update `SystemMemory(key="active_session")` with the new session ID and date.
+
+If the old session is corrupted or the CLI fails to resume it, skip the summary and create a fresh session from DB state. The training plan and training log are the durable source of truth — the session is a disposable cache.
+
+### Concurrency guard
+
+Session continuity introduces ordering requirements. Two concurrent requests resuming the same session would race or fork the conversation.
+
+```python
+_session_lock = asyncio.Lock()
+
+async def _call_claude_session(...):
+    async with _session_lock:
+        # only one CLI call at a time per session
+        ...
+```
+
+This is acceptable for a single-user app. Concurrent taps queue behind the lock rather than spawning parallel processes.
+
+### Tool-use: 2 calls max
+
+Current state: up to 3 blind subprocess spawns per tool request, each re-sending full context with no memory of prior calls.
+
+New state: tools execute within the session.
+
+```
+Call 1: claude --print --resume <session-uuid> --tools "" -p "user message"
+  → Response includes tool_calls → server executes them
+
+Call 2: claude --print --resume <session-uuid> --tools "" -p "Tool results: {results}"
+  → Claude responds with confirmation
+```
+
+If no tool_calls in the response, it's just 1 call. Both calls share session context so Claude knows the original user message when processing tool results.
+
+The text-based tool description approach stays in the system prompt (native tool-use requires the SDK). Reliability improves because Claude has full conversation context across tool iterations instead of a stateless follow-up.
+
+### Streaming for chat
+
+Chat responses use `--output-format stream-json --verbose` instead of `--print`. The server parses the JSONL stream and pipes `assistant` events to the frontend as SSE.
+
+**Stream event format** (from testing):
+```jsonl
+{"type":"system","subtype":"init",...}
+{"type":"assistant","message":{"content":[{"type":"text","text":"..."}],...}}
+{"type":"result","subtype":"success",...}
+```
+
+The server filters for `type=assistant` events and extracts the text content.
+
+**Backend:**
+```python
+# FastAPI StreamingResponse
+async def stream_chat(...):
+    proc = await asyncio.create_subprocess_exec(
+        CLAUDE_BIN, "--print", "--resume", session_id,
+        "--output-format", "stream-json", "--verbose",
+        "--tools", "", "-p", message,
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+    )
+    # yield SSE events as assistant text arrives
+```
+
+**Frontend:** `fetch` with `ReadableStream` (not `EventSource`, which doesn't support POST).
+
+**Tool-action follow-ups** use `--print` (non-streaming) since the response is short. The frontend displays the streamed first response, then appends the tool confirmation as a second message.
+
+### Context diet
+
+With session continuity, most context is sent once per day instead of every message.
+
+| Data | First message of day | Subsequent messages |
+|------|---------------------|-------------------|
+| System prompt | Full (~1900 tokens) | In session |
+| Training program | Full (~660 tokens) | In session |
+| Profile | Full (~100 tokens) | In session |
+| Yesterday's summary | Yes (~50 tokens) | In session |
+| Whoop biometrics | Today's data | Only if refreshed |
+| Meal totals | Current | Only if new meal logged |
+| Training log (last 15) | Full | In session |
+| Conversation history | Not needed | In session |
+| New user message | Yes | Yes |
+
+Estimated context per call: ~4000 tokens (first) → ~100-200 tokens (subsequent).
+
+### Unblock concurrent updates
+
+Remove the guard that blocks `memory_update` when `training_log_entry` is present (`chat.py` line 198). Claude should be able to both log a workout completion and adjust next week's program in the same response.
+
+Add a safety check instead: if `memory_update` is present, diff it against the current training plan. If it's significantly shorter (>50% reduction), log a warning and keep the old version. This prevents accidental truncation without blocking legitimate updates.
+
+### Session recovery
+
+If `claude --print --resume <session_id>` fails (corrupted session, CLI update, missing file):
+
+1. Log the error.
+2. Delete the broken session file.
+3. Create a new session with full context from DB.
+4. Continue as if it's the first message of the day.
+
+The training plan and training log are the source of truth. The session is a convenience layer — losing it means one slower request while context is rebuilt, not data loss.
+
+### Initial cleanup
+
+On first deploy, delete all existing stale sessions:
+```bash
+rm -f ~/.claude/projects/-home-deck-spotme/*.jsonl
+```
+This reclaims 84MB immediately. Going forward, only 1 session file exists at a time.
+
+## Files to change
+
+### Backend
+
+| File | Change |
+|------|--------|
+| `server/services/claude_service.py` | Replace `_call_claude()` with session-aware `_call_claude_session()`. Add `_get_or_create_session()`, `_handoff_session()`, `_stream_claude_session()`. Replace `_call_claude_with_tools()` with 2-call session pattern. Add `asyncio.Lock` for concurrency. Keep `_call_claude()` with `--no-session-persistence` for stateless calls (interview questions, form analysis). Keep `_extract_json()` for `--print` responses. |
+| `server/routes/chat.py` | Update `chat()` to use session-aware service. Add `GET /api/chat/stream` SSE endpoint. Remove the `memory_update` + `training_log_entry` mutual exclusion guard. Add length-based safety check for memory updates. |
+| `server/models.py` | No new models. `SystemMemory(key="active_session")` stores `{"session_id": "...", "date": "2026-03-23"}` as JSON. |
+| `server/config.py` | Add `SESSION_ROLLOVER_HOUR = 4` constant. |
+
+### Frontend
+
+| File | Change |
+|------|--------|
+| `frontend/src/api.ts` | Add `chatStream()` method using `fetch` with `ReadableStream` for SSE parsing. |
+| `frontend/src/screens/workout.tsx` | Update `send()` to use streaming. Append tokens incrementally to the assistant message. Fall back to non-streaming on error. |
+
+### Cleanup
+
+| File | Change |
+|------|--------|
+| `server/routes/video.py`, `server/routes/layout.py` | Remove stale `api_key=settings.anthropic_api_key` arguments from `ClaudeService()` calls. |
+| Deploy script | One-time: `rm -f ~/.claude/projects/-home-deck-spotme/*.jsonl` |
+
+## What stays the same
+
+- System prompt content and structure (coaching rules, response format, tool behavior)
+- All database models and schemas
+- Training plan stored as markdown in SystemMemory
+- TrainingLog append-only pattern
+- Whoop integration (lazy imports, try/except, graceful degradation)
+- Frontend component structure and layout system
+- PWA offline capabilities
+- `generate_interview_questions()` and `analyze_form()` remain stateless (`--print --no-session-persistence`)
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| `--resume` may not work with `--append-system-prompt` | Test first. Fallback: embed system prompt in first user message as a `[SYSTEM]` block. |
+| `--output-format stream-json` requires `--verbose` (extra noise) | Filter events server-side, only forward `type=assistant` to frontend. |
+| CLI update breaks session file format | Session recovery rebuilds from DB. No data loss. |
+| Daily summary quality varies | Summary is additive (training log entry). Raw log entries still carry the facts. |
+| Concurrent rapid taps | `asyncio.Lock` queues requests. Second tap waits for first to complete. |
+| Session file grows very large after many messages | Monitor. If needed, trigger mid-day rollover at a message count threshold. |
+
+## Success criteria
+
+- Only 1 session file on disk at any time (down from 211)
+- Chat responses begin streaming within 3-5 seconds (after CLI startup)
+- Tool-use completes in 2 CLI calls, not 3
+- Context sent per message drops from ~4000 to ~200 tokens after first message
+- Claude remembers earlier conversations within the same day without re-sending history
+- Program adjustments from feedback persist across days via training log
+- No RAM bloat from orphaned processes
+- 84MB of stale session files reclaimed on deploy

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -15,6 +15,34 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 export const api = {
   interviewQuestions: (profile: { name: string; experience: string; goals: string; frequency: string; equipment: string }) => request<{ questions: string[] }>('/interview/questions', { method: 'POST', body: JSON.stringify(profile) }),
   chat: (message: string, workoutId?: number, date?: string) => request<import('./types').ChatResponse>('/chat', { method: 'POST', body: JSON.stringify({ message, workout_id: workoutId ?? null, date: date ?? null }) }),
+  chatStream: async (message: string, date?: string, onToken?: (text: string) => void): Promise<string> => {
+    const resp = await fetch(`${BASE}/chat/stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message, workout_id: null, date: date ?? null }),
+    })
+    if (!resp.ok) throw new Error(`API error: ${resp.status}`)
+    const reader = resp.body!.getReader()
+    const decoder = new TextDecoder()
+    let full = ''
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      const chunk = decoder.decode(value, { stream: true })
+      for (const line of chunk.split('\n')) {
+        if (!line.startsWith('data: ')) continue
+        try {
+          const data = JSON.parse(line.slice(6))
+          if (data.done) return full
+          if (data.text) {
+            full += data.text
+            onToken?.(full)
+          }
+        } catch { /* partial json line, skip */ }
+      }
+    }
+    return full
+  },
   startWorkout: (type?: string) => request<{ id: number; date: string; status: string; resumed: boolean }>('/workout/start', { method: 'POST', body: JSON.stringify({ type: type ?? 'strength' }) }),
   getRecentWorkouts: () => request<Array<{ id: number; date: string; type: string; status: string; duration: number | null; exercises: Array<{ name: string; sets: Array<{ weight: number; reps: number; rpe: number | null }> }>; recovery: number | null }>>('/workout/recent'),
   getPrs: () => request<{ prs: Array<{ exercise: string; weight: number; reps: number; e1rm: number; date: string }> }>('/progress/prs'),

--- a/frontend/src/components/program-day.tsx
+++ b/frontend/src/components/program-day.tsx
@@ -86,10 +86,29 @@ function LoggedBody({ exercises, summary }: { exercises: ExerciseData[]; summary
   )
 }
 
+function splitExercises(text: string): string[] {
+  // split on commas, but not inside parentheses
+  const parts: string[] = []
+  let depth = 0
+  let current = ''
+  for (const ch of text) {
+    if (ch === '(') depth++
+    else if (ch === ')') depth = Math.max(0, depth - 1)
+    if (ch === ',' && depth === 0) {
+      const trimmed = current.trim()
+      if (trimmed) parts.push(trimmed)
+      current = ''
+    } else {
+      current += ch
+    }
+  }
+  const trimmed = current.trim()
+  if (trimmed) parts.push(trimmed)
+  return parts
+}
+
 function PlannedBody({ day }: { day: DayData }) {
-  const exercises = day.planned
-    ? day.planned.split(',').map(e => e.trim()).filter(Boolean)
-    : []
+  const exercises = day.planned ? splitExercises(day.planned) : []
   return (
     <div>
       {exercises.map((ex, i) => (
@@ -113,9 +132,7 @@ export function ProgramDay({ day }: { day: DayData }) {
   const statusClass = day.status === 'completed' ? 'completed'
     : day.status === 'today' ? 'today' : 'upcoming'
 
-  const plannedExercises = day.planned
-    ? day.planned.split(',').map(e => e.trim()).filter(Boolean)
-    : []
+  const plannedExercises = day.planned ? splitExercises(day.planned) : []
 
   const hasLoggedData = day.source === 'logged' && day.exercises && day.exercises.length > 0
 

--- a/frontend/src/components/program-view.tsx
+++ b/frontend/src/components/program-view.tsx
@@ -14,6 +14,7 @@ interface WeekData {
   number: number
   title: string
   days: DayData[]
+  start_date?: string | null
 }
 
 interface ProgressionPoint { week: number; weight: number; label: string }

--- a/frontend/src/components/program-week.tsx
+++ b/frontend/src/components/program-week.tsx
@@ -14,13 +14,24 @@ interface DayData {
 }
 
 interface WeekProps {
-  week: { number: number; title: string; days: DayData[] }
+  week: { number: number; title: string; days: DayData[]; start_date?: string | null }
   today: string
 }
 
-export function ProgramWeek({ week }: WeekProps) {
-  const isCurrentWeek = week.title.toLowerCase().includes('current') ||
-    week.days.some(d => d.status === 'completed')
+function isWeekCurrent(week: WeekProps['week'], today: string): boolean {
+  if (week.title.toLowerCase().includes('current')) return true
+  if (week.start_date) {
+    const start = new Date(week.start_date + 'T00:00:00')
+    const end = new Date(start)
+    end.setDate(end.getDate() + 7)
+    const t = new Date(today + 'T00:00:00')
+    return t >= start && t < end
+  }
+  return false
+}
+
+export function ProgramWeek({ week, today }: WeekProps) {
+  const isCurrentWeek = isWeekCurrent(week, today)
   const [open, setOpen] = useState(isCurrentWeek)
   const [enrichedDays, setEnrichedDays] = useState<DayData[] | null>(null)
 
@@ -31,9 +42,9 @@ export function ProgramWeek({ week }: WeekProps) {
       .catch(() => {})
   }, [open, week.number])
 
-  const completedDays = week.days.filter(d => d.status === 'completed').length
-  const totalDays = week.days.length
   const displayDays = enrichedDays ?? week.days
+  const completedDays = displayDays.filter(d => d.status === 'completed').length
+  const totalDays = week.days.length
 
   return (
     <div className={`program-week${isCurrentWeek ? ' current' : ''}`}>

--- a/frontend/src/screens/workout.tsx
+++ b/frontend/src/screens/workout.tsx
@@ -42,6 +42,36 @@ export function Workout() {
       .catch(() => setMessages([]))
   }, [chatDate, workoutId])
 
+  // recover server-saved responses after tab switch / screen off
+  const chatDateRef = useRef(chatDate)
+  chatDateRef.current = chatDate
+  const workoutIdRef = useRef(workoutId)
+  workoutIdRef.current = workoutId
+  useEffect(() => {
+    const handler = () => {
+      if (document.hidden) return
+      const wid = workoutIdRef.current
+      if (wid && wid > 0) {
+        api.getChatHistory(wid)
+          .then(r => {
+            const msgs = r.map(m => ({ role: m.role as 'user' | 'assistant', content: m.content }))
+            if (msgs.length > 0) setMessages(msgs)
+          })
+          .catch(() => {})
+      } else {
+        api.getChatDay(chatDateRef.current)
+          .then(r => {
+            const msgs = r.messages.map(m => ({ role: m.role as 'user' | 'assistant', content: m.content }))
+            if (msgs.length > 0) setMessages(msgs)
+          })
+          .catch(() => {})
+      }
+      setThinking(false)
+    }
+    document.addEventListener('visibilitychange', handler)
+    return () => document.removeEventListener('visibilitychange', handler)
+  }, [])
+
   const endWorkout = async () => {
     if (workoutId && workoutId > 0) {
       try { await api.completeWorkout(workoutId) } catch {}
@@ -90,12 +120,26 @@ export function Workout() {
     setThinking(true)
     try {
       const wid = workoutId && workoutId > 0 ? workoutId : undefined
-      const result = await api.chat(text, wid, wid ? undefined : chatDate)
-      setMessages(m => [...m, { role: 'assistant', content: result.response }])
-      if (result.workout_active && result.current_set) {
-        setWorkoutId(result.workout_id ?? null)
-        setCurrentSet(result.current_set)
-        setSetProgress({ completed: 0, total: 0, current_exercise_progress: '0 of 0' })
+      if (wid) {
+        // active workout: non-streaming (needs workout_id for set sequencing)
+        const result = await api.chat(text, wid, wid ? undefined : chatDate)
+        setMessages(m => [...m, { role: 'assistant', content: result.response }])
+        if (result.workout_active && result.current_set) {
+          setWorkoutId(result.workout_id ?? null)
+          setCurrentSet(result.current_set)
+          setSetProgress({ completed: 0, total: 0, current_exercise_progress: '0 of 0' })
+        }
+      } else {
+        // daily chat: stream tokens
+        setMessages(m => [...m, { role: 'assistant', content: '' }])
+        setThinking(false)
+        await api.chatStream(text, chatDate, (partial) => {
+          setMessages(m => {
+            const updated = [...m]
+            updated[updated.length - 1] = { role: 'assistant', content: partial }
+            return updated
+          })
+        })
       }
     } catch {
       setMessages(m => [...m, { role: 'assistant', content: 'Connection error — try again in a sec.' }])

--- a/server/config.py
+++ b/server/config.py
@@ -20,3 +20,5 @@ TIMEZONE = ZoneInfo("America/New_York")
 
 def today_eastern() -> str:
     return datetime.now(TIMEZONE).strftime("%Y-%m-%d")
+
+SESSION_ROLLOVER_HOUR = 4

--- a/server/main.py
+++ b/server/main.py
@@ -110,6 +110,7 @@ def create_app():
     from server.routes.program import router as program_router
     from server.routes.meals import router as meals_router
     from server.routes.interview import router as interview_router
+    from server.routes.chat_stream import router as chat_stream_router
     app.include_router(chat_router, prefix="/api")
     app.include_router(workout_router, prefix="/api")
     app.include_router(video_router, prefix="/api")
@@ -121,6 +122,7 @@ def create_app():
     app.include_router(program_router, prefix="/api")
     app.include_router(meals_router, prefix="/api")
     app.include_router(interview_router, prefix="/api")
+    app.include_router(chat_stream_router, prefix="/api")
 
     if FRONTEND_DIR.exists():
         # serve static assets (js, css, icons, manifest, sw)

--- a/server/routes/chat.py
+++ b/server/routes/chat.py
@@ -1,5 +1,6 @@
 import asyncio
 import json as json_lib
+import logging
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from server.database import get_db
@@ -13,6 +14,8 @@ from server.models import (
 )
 from server.config import today_eastern
 from server.utils import recovery_zone
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -168,7 +171,7 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
     if request_date != today:
         context += f"\n\nNote: athlete is reviewing {request_date} on {today}."
     service = ClaudeService()
-    result = await service.chat(request.message, context, db=db)
+    result = await service.chat(request.message, context, db=db, date=request_date)
 
     # auto-save profile
     profile_data = result.get("profile")
@@ -193,10 +196,13 @@ async def chat(request: ChatRequest, db: Session = Depends(get_db)):
     # extract log entry early so the memory guard can reference it
     log_entry = result.get("training_log_entry")
 
-    # save memory — block if a log entry is present (prevents accidental program truncation)
+    # save memory — allow concurrent with training_log_entry, but guard against truncation
     memory_update = result.get("memory_update")
-    if memory_update and isinstance(memory_update, str) and not log_entry:
-        if memory_row:
+    if memory_update and isinstance(memory_update, str):
+        existing_len = len(memory_row.content or "") if memory_row else 0
+        if existing_len > 0 and len(memory_update) < existing_len * 0.5:
+            logger.warning("blocked memory_update: %d chars vs existing %d chars (>50%% reduction)", len(memory_update), existing_len)
+        elif memory_row:
             memory_row.content = memory_update
         else:
             db.add(SystemMemory(key=MEMORY_KEY, content=memory_update))

--- a/server/routes/chat_stream.py
+++ b/server/routes/chat_stream.py
@@ -1,0 +1,160 @@
+import asyncio
+import json
+import logging
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+from server.database import get_db
+from server.services.claude_service import (
+    CLAUDE_BIN, MODEL, SYSTEM_PROMPT, _session_lock, assemble_context,
+)
+from server.services.session_manager import SessionManager
+from server.models import (
+    SystemMemory, Conversation, UserProfile, WhoopData, Meal, TrainingLog,
+)
+from server.config import today_eastern
+from server.schemas import ChatRequest
+from sqlalchemy import func as sqlfunc
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+session_mgr = SessionManager()
+
+
+def _build_context(db: Session):
+    """build claude context from db state (shared logic with chat route)"""
+    profile = db.query(UserProfile).first()
+    profile_dict = None
+    if profile:
+        profile_dict = {
+            "name": profile.name, "goals": profile.goals,
+            "experience_level": profile.experience_level,
+            "equipment": profile.equipment,
+            "training_frequency": profile.training_frequency,
+            "injuries_notes": profile.injuries_notes,
+            "calorie_target": profile.calorie_target,
+            "protein_target": profile.protein_target,
+        }
+
+    whoop_dict = None
+    whoop = db.query(WhoopData).filter_by(date=today_eastern()).first()
+    if whoop:
+        whoop_dict = {
+            "recovery_score": whoop.recovery_score, "hrv": whoop.hrv,
+            "resting_hr": whoop.resting_hr, "sleep_score": whoop.sleep_score,
+            "sleep_duration": whoop.sleep_duration, "strain": whoop.strain,
+        }
+
+    memory_row = db.query(SystemMemory).filter_by(key="training_plan").first()
+    memory_text = memory_row.content if memory_row else None
+
+    recent_logs = (
+        db.query(TrainingLog).order_by(TrainingLog.id.desc()).limit(15).all()
+    )
+    training_log_dicts = [
+        {"date": log.date, "type": log.log_type, "content": log.content}
+        for log in reversed(recent_logs)
+    ]
+
+    # today's meal totals
+    meal_row = db.query(
+        sqlfunc.sum(Meal.calories).label("calories"),
+        sqlfunc.sum(Meal.protein).label("protein"),
+        sqlfunc.sum(Meal.carbs).label("carbs"),
+        sqlfunc.sum(Meal.fat).label("fat"),
+    ).filter(Meal.date == today_eastern()).first()
+    meal_totals = None
+    if meal_row and meal_row.calories:
+        meal_totals = {
+            "calories": meal_row.calories,
+            "protein": round(meal_row.protein or 0, 1),
+            "carbs": round(meal_row.carbs or 0, 1),
+            "fat": round(meal_row.fat or 0, 1),
+        }
+
+    return assemble_context(
+        None, None, whoop_dict, [], profile_dict, memory_text,
+        training_log=training_log_dicts, db=db, meal_totals=meal_totals,
+    )
+
+
+@router.post("/chat/stream")
+async def stream_chat(request: ChatRequest, db: Session = Depends(get_db)):
+    """sse endpoint that streams claude's response token by token"""
+    message = request.message
+    request_date = request.date or today_eastern()
+
+    context = _build_context(db)
+
+    is_first = session_mgr.is_first_message(db, request_date)
+    if session_mgr.needs_handoff(db, request_date):
+        from server.services.claude_service import ClaudeService
+        svc = ClaudeService()
+        await svc._do_handoff(db, request_date)
+
+    session_id = session_mgr.get_or_create_session_id(db, request_date)
+
+    args = [
+        CLAUDE_BIN, "--print", "--output-format", "stream-json",
+        "--verbose", "--tools", "",
+    ]
+    if is_first:
+        args.extend([
+            "--session-id", session_id,
+            "--model", MODEL,
+            "--append-system-prompt", SYSTEM_PROMPT,
+        ])
+        msg = f"Current context:\n{context}\n\n{message}"
+    else:
+        args.extend(["--resume", session_id])
+        msg = message
+    args.extend(["-p", msg])
+
+    async def event_stream():
+        # acquire lock only to start the process, then release
+        async with _session_lock:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        # stream outside the lock
+        full_text = ""
+        try:
+            async for line in proc.stdout:
+                decoded = line.decode().strip()
+                if not decoded:
+                    continue
+                try:
+                    event = json.loads(decoded)
+                except json.JSONDecodeError:
+                    continue
+                if event.get("type") == "assistant":
+                    content = event.get("message", {}).get("content", [])
+                    for block in content:
+                        if block.get("type") == "text":
+                            text = block["text"]
+                            full_text += text
+                            yield f"data: {json.dumps({'text': text})}\n\n"
+            await proc.wait()
+        except Exception as e:
+            logger.error("stream error: %s", e)
+            proc.kill()
+            await proc.wait()
+
+        # save conversation
+        db.add(Conversation(
+            role="user", content=message,
+            context_type="chat", date=request_date,
+        ))
+        db.add(Conversation(
+            role="assistant", content=full_text,
+            context_type="chat", date=request_date,
+        ))
+        db.commit()
+
+        yield f"data: {json.dumps({'done': True})}\n\n"
+
+    return StreamingResponse(
+        event_stream(), media_type="text/event-stream",
+    )

--- a/server/routes/layout.py
+++ b/server/routes/layout.py
@@ -14,12 +14,11 @@ async def get_layout(screen: str = "dashboard", db: Session = Depends(get_db)):
     whoop = db.query(WhoopData).order_by(WhoopData.date.desc()).first()
     whoop_dict = {"recovery_score": whoop.recovery_score, "hrv": whoop.hrv, "sleep_score": whoop.sleep_score} if whoop else None
     context = assemble_context(program_dict, None, whoop_dict, [])
-    if settings.anthropic_api_key:
-        try:
-            service = ClaudeService(api_key=settings.anthropic_api_key)
-            result = await service.chat(f"Generate a {screen} layout for the user. Return layout JSON only.", context)
-            if result["layout"]:
-                return result["layout"]
-        except Exception:
-            pass
+    try:
+        service = ClaudeService()
+        result = await service.chat(f"Generate a {screen} layout for the user. Return layout JSON only.", context)
+        if result["layout"]:
+            return result["layout"]
+    except Exception:
+        pass
     return {"screen": screen, "layout": [{"type": "header", "title": "SpotMe", "subtitle": "Welcome back"}, {"type": "action_button", "label": "Start Workout", "action": "start_workout"}]}

--- a/server/routes/program.py
+++ b/server/routes/program.py
@@ -19,11 +19,21 @@ async def get_program(db: Session = Depends(get_db)):
     result = parse_program(memory.content)
 
     total = db.query(Workout).count()
-    completed = db.query(Workout).filter_by(status="completed").count()
+    # count workouts with at least one exercise logged (not just status=completed)
+    completed = (
+        db.query(Workout)
+        .filter(Workout.id.in_(
+            db.query(Exercise.workout_id).distinct()
+        ))
+        .count()
+    )
 
     return {
         "has_program": True,
-        "weeks": result["weeks"],
+        "weeks": [
+            {**w, "start_date": w.get("start_date")}
+            for w in result["weeks"]
+        ],
         "progression": result["progression"],
         "stats": {
             "total_workouts": total,
@@ -31,6 +41,47 @@ async def get_program(db: Session = Depends(get_db)):
             "today": date.today().isoformat(),
         },
     }
+
+
+_DAY_KEYWORDS = {
+    "pull": ["pull-up", "pullup", "row", "lat", "curl", "shrug", "face pull"],
+    "back": ["pull-up", "pullup", "row", "lat", "curl", "shrug", "face pull"],
+    "bench": ["bench press", "db flat press", "cable fly", "flye", "tricep"],
+    "heavy": ["bench press", "db flat press", "cable fly", "flye", "tricep"],
+    "volume": ["bench press", "db flat press", "cable fly", "flye", "tricep"],
+    "legs": ["deadlift", "squat", "leg press", "leg curl", "calf", "rdl", "lunge"],
+    "arms": ["curl", "tricep", "extension", "pushdown"],
+    "shoulders": ["lateral raise", "ohp", "shoulder press"],
+}
+
+
+def _score_workout_match(exercise_names: list[str], day_type: str) -> int:
+    """score how well a workout's exercises match a program day type"""
+    text = ' '.join(e.lower() for e in exercise_names)
+    best_score = 0
+    for word in day_type.lower().split():
+        keywords = _DAY_KEYWORDS.get(word, [])
+        score = sum(1 for kw in keywords if kw in text)
+        best_score = max(best_score, score)
+    return best_score
+
+
+# day-of-week offsets from the sunday start_date
+# pull/back (fri) opens the new cycle (-2), legs (sat) CLOSES the cycle (+6)
+_DAY_OFFSETS = {
+    "Fri": -2, "Sat": 6, "Sun": 0, "Mon": 1,
+    "Tue": 2, "Tue/Wed": 2, "Wed": 3, "Thu": 4,
+}
+
+
+def _expected_date(start_date: str, day_abbrev: str) -> str | None:
+    """calculate the expected calendar date for a program day"""
+    from datetime import datetime, timedelta
+    offset = _DAY_OFFSETS.get(day_abbrev)
+    if offset is None:
+        return None
+    dt = datetime.fromisoformat(start_date) + timedelta(days=offset)
+    return dt.date().isoformat()
 
 
 @router.get("/program/week/{week_number}")
@@ -47,31 +98,65 @@ async def get_program_week(week_number: int, db: Session = Depends(get_db)):
     if not week:
         return {"week": week_number, "days": []}
 
-    completed_workouts = db.query(Workout).filter_by(status="completed").all()
+    # fetch all workouts in a broad range around this week
+    start_date = week.get("start_date")
+    if start_date:
+        from datetime import datetime, timedelta
+        start_dt = datetime.fromisoformat(start_date)
+        range_start = (start_dt - timedelta(days=3)).date().isoformat()
+        range_end = (start_dt + timedelta(days=8)).date().isoformat()
+        all_workouts = (
+            db.query(Workout)
+            .filter(Workout.date >= range_start, Workout.date < range_end)
+            .all()
+        )
+    else:
+        all_workouts = db.query(Workout).all()
+
+    # preload exercise names per workout
+    workout_exercises: dict[int, list[str]] = {}
+    for w in all_workouts:
+        exercises = db.query(Exercise).filter_by(workout_id=w.id).all()
+        workout_exercises[w.id] = [e.name for e in exercises]
+
+    # only consider workouts with logged exercises
+    all_workouts = [w for w in all_workouts if workout_exercises.get(w.id)]
+
+    used_workout_ids: set[int] = set()
 
     enriched_days = []
     for day in week.get("days", []):
         day_data = {**day, "exercises": [], "source": "planned", "summary": None}
 
-        if day["status"] != "completed":
+        # find the best workout: must match by exercise type AND be near the expected date
+        expected = _expected_date(start_date, day["day_of_week"]) if start_date else None
+        best_match = None
+        best_score = 0
+        for w in all_workouts:
+            if w.id in used_workout_ids:
+                continue
+            # skip workouts too far from expected date (±1 day tolerance)
+            if expected and w.date:
+                from datetime import datetime
+                diff = abs((datetime.fromisoformat(w.date) - datetime.fromisoformat(expected)).days)
+                if diff > 1:
+                    continue
+            score = _score_workout_match(workout_exercises[w.id], day["type"])
+            if score > best_score:
+                best_score = score
+                best_match = w
+
+        min_score = 2 if best_match and len(workout_exercises.get(best_match.id, [])) >= 5 else 1
+        if not best_match or best_score < min_score:
             enriched_days.append(day_data)
             continue
 
-        # find the best-matching completed workout by type keyword
-        day_first_word = day["type"].lower().split()[0]
-        matched_workout = None
-        for w in completed_workouts:
-            if day_first_word in (w.type or "").lower():
-                matched_workout = w
-
-        if not matched_workout:
-            enriched_days.append(day_data)
-            continue
-
+        used_workout_ids.add(best_match.id)
         day_data["source"] = "logged"
+        day_data["status"] = "completed"
         exercises = (
             db.query(Exercise)
-            .filter_by(workout_id=matched_workout.id)
+            .filter_by(workout_id=best_match.id)
             .order_by(Exercise.order)
             .all()
         )

--- a/server/routes/video.py
+++ b/server/routes/video.py
@@ -17,7 +17,7 @@ async def analyze_video(file: UploadFile = File(...), exercise: str = "unknown e
     video_path = await video_service.save_upload(await file.read(), filename)
     frames = await video_service.extract_frames(video_path, num_frames=3)
     context = f"{exercise} at {weight}lbs, set {set_number}"
-    claude = ClaudeService(api_key=settings.anthropic_api_key)
+    claude = ClaudeService()
     result = await claude.analyze_form(frames, context)
     form_check = FormCheck(video_path=video_path, frames_extracted=len(frames), claude_analysis=result["analysis"])
     db.add(form_check)

--- a/server/services/claude_service.py
+++ b/server/services/claude_service.py
@@ -83,9 +83,14 @@ Signal priority when conflicting: sleep hours > HRV trend > daily recovery score
 - Lower back: if user reports tightness on rows/deadlifts, don't increase weight, suggest bracing cues.
 - These thresholds calibrate over time. Use RPE feedback as ground truth.
 
-### Tool Behavior
-- Low-risk tools (log activity, update weight): execute then announce. Don't ask permission.
-- Destructive tools (delete activity): confirm with user first.
+### Action Bias
+- Be proactive. NEVER ask for permission or confirmation before taking action. This includes:
+  - Logging activities, updating weight, setting alarms — just do it and report what you did
+  - Updating training memory when the user provides corrections or new info — just update it
+  - Recording training log entries — just log them
+  - Estimating and tracking meals — just do it
+- The ONLY exception: deleting activities from Whoop (destructive, confirm first)
+- Do NOT say "Would you like me to...", "Should I...", "Want me to...", or "I can..." followed by a question. Act, then announce.
 - On tool error: say "Whoop disconnected" or "couldn't reach Whoop". Never show technical details.
 
 ### User Override
@@ -114,6 +119,8 @@ Be specific about your estimates. If the user just says "I had chicken and rice"
 
 RECOVERY_GREEN = 67
 RECOVERY_YELLOW = 34
+
+_session_lock = asyncio.Lock()
 
 WHOOP_TOOLS = [
     {
@@ -293,20 +300,7 @@ class ClaudeService:
     async def chat(self, message: str, context: str, db=None) -> dict:
         system = f"{SYSTEM_PROMPT}\n\nCurrent context:\n{context}"
         try:
-            from server.models import WhoopToken
-            whoop_connected = db.query(WhoopToken).first() is not None if db else False
-
-            if whoop_connected:
-                from server.services.whoop_tools import execute_whoop_tool
-                raw_text = await _call_claude_with_tools(
-                    system_prompt=system,
-                    message=message,
-                    tools=WHOOP_TOOLS,
-                    tool_executor=execute_whoop_tool,
-                    db=db,
-                )
-            else:
-                raw_text = await _call_claude(system, message)
+            raw_text = await _call_claude_stateless(system, message)
         except Exception as e:
             logger.error("claude call failed: %s", e)
             return {"response": "Having trouble reaching Claude right now. Try again in a sec.", "layout": None, "profile": None, "memory_update": None, "training_log_entry": None, "set_suggestion": None, "meal": None, "workout_plan": None}
@@ -340,7 +334,7 @@ class ClaudeService:
             "weak points, PRs they're chasing, injury history, preferred training style.\n"
             "Return ONLY a JSON array of question strings, nothing else."
         )
-        raw = await _call_claude(system, f"Athlete profile: {profile_summary}")
+        raw = await _call_claude_stateless(system, f"Athlete profile: {profile_summary}")
         try:
             # handle both raw array and code-fenced array
             import re
@@ -367,7 +361,7 @@ class ClaudeService:
     async def analyze_form(self, frames_base64: list, context: str) -> dict:
         system = "You are a strength coach analyzing lifting form. Identify issues, suggest corrections, note what looks good."
         message = f"Analyze this lifting form. Context: {context}"
-        raw_text = await _call_claude(system, message)
+        raw_text = await _call_claude_stateless(system, message)
         return {"analysis": raw_text}
 
 
@@ -388,11 +382,49 @@ def _extract_json(text: str) -> str:
     return stripped
 
 
-async def _call_claude(system_prompt: str, message: str) -> str:
-    """call claude via CLI subprocess (inherits OAuth session)."""
+async def _call_claude_session(
+    session_id: str,
+    message: str,
+    is_first: bool = False,
+    system_prompt: str | None = None,
+) -> str:
+    """call claude within a persistent daily session."""
+    async with _session_lock:
+        args = [CLAUDE_BIN, "--print", "--tools", ""]
+        if is_first:
+            args.extend(["--session-id", session_id, "--model", MODEL])
+            if system_prompt:
+                args.extend(["--append-system-prompt", system_prompt])
+        else:
+            args.extend(["--resume", session_id])
+        args.extend(["-p", message])
+
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise RuntimeError("claude cli timed out after 120s")
+        if proc.returncode != 0:
+            error = stderr.decode().strip()
+            logger.error("claude session error: %s", error)
+            raise RuntimeError(f"claude cli failed: {error}")
+        raw = stdout.decode().strip()
+        return _extract_json(raw)
+
+
+async def _call_claude_stateless(system_prompt: str, message: str) -> str:
+    """call claude without session persistence (for one-off calls)."""
     proc = await asyncio.create_subprocess_exec(
         CLAUDE_BIN, "--print",
+        "--no-session-persistence",
         "--model", MODEL,
+        "--tools", "",
         "--append-system-prompt", system_prompt,
         "-p", message,
         stdout=asyncio.subprocess.PIPE,
@@ -410,54 +442,3 @@ async def _call_claude(system_prompt: str, message: str) -> str:
         raise RuntimeError(f"claude cli failed: {error}")
     raw = stdout.decode().strip()
     return _extract_json(raw)
-
-
-MAX_TOOL_ITERATIONS = 3
-
-
-async def _call_claude_with_tools(
-    system_prompt: str,
-    message: str,
-    tools: list[dict],
-    tool_executor,
-    db,
-    history: list[dict] | None = None,
-) -> str:
-    """call claude with tool-use via CLI, parsing tool calls from JSON response."""
-    # embed tool descriptions in the system prompt
-    tool_desc = "\n\n## Available Tools\n"
-    tool_desc += "When you need to use a tool, include a \"tool_calls\" array in your JSON response:\n"
-    tool_desc += '{"response": "...", "tool_calls": [{"name": "tool_name", "arguments": {...}}]}\n'
-    tool_desc += "After tool execution, you'll receive results and can respond.\n\n"
-    for tool in tools:
-        params = tool["input_schema"].get("properties", {})
-        required = tool["input_schema"].get("required", [])
-        param_strs = [f"  - {k} ({'required' if k in required else 'optional'}): {v.get('description', v.get('type', ''))}" for k, v in params.items()]
-        tool_desc += f"### {tool['name']}\n{tool['description']}\nParameters:\n" + "\n".join(param_strs) + "\n\n"
-
-    full_system = system_prompt + tool_desc
-
-    for iteration in range(MAX_TOOL_ITERATIONS):
-        if iteration == 0:
-            raw_text = await _call_claude(full_system, message)
-        else:
-            # follow-up with tool results
-            followup = f"Tool results:\n{json.dumps(tool_results_summary)}\n\nRespond to the user based on these results."
-            raw_text = await _call_claude(full_system, followup)
-
-        try:
-            parsed = json.loads(raw_text)
-        except json.JSONDecodeError:
-            return raw_text
-
-        tool_calls = parsed.get("tool_calls", [])
-        if not tool_calls:
-            return raw_text
-
-        # execute tool calls
-        tool_results_summary = []
-        for tc in tool_calls:
-            result = await tool_executor(tc["name"], tc.get("arguments", {}), db)
-            tool_results_summary.append({"tool": tc["name"], "result": result})
-
-    return raw_text

--- a/server/services/claude_service.py
+++ b/server/services/claude_service.py
@@ -297,13 +297,108 @@ def assemble_context(program, workout, whoop, history, profile=None, memory=None
 
 class ClaudeService:
 
-    async def chat(self, message: str, context: str, db=None) -> dict:
+    def __init__(self):
+        from server.services.session_manager import SessionManager
+        self.session_mgr = SessionManager()
+
+    async def chat(self, message: str, context: str, db=None, date: str | None = None) -> dict:
+        from server.config import today_eastern
+        today = date or today_eastern()
+
+        # fallback to stateless when no db available (unit tests, intake)
+        if db is None:
+            return await self._chat_stateless(message, context)
+
+        is_first = self.session_mgr.is_first_message(db, today)
+
+        # daily handoff: summarize old session before creating new
+        if self.session_mgr.needs_handoff(db, today):
+            await self._do_handoff(db, today)
+
+        session_id = self.session_mgr.get_or_create_session_id(db, today)
+
+        try:
+            if is_first:
+                # first message: system prompt in --append-system-prompt, context + user msg in -p
+                raw_text = await _call_claude_session(
+                    session_id=session_id,
+                    message=f"Current context:\n{context}\n\n{message}",
+                    is_first=True,
+                    system_prompt=SYSTEM_PROMPT,
+                )
+            else:
+                raw_text = await _call_claude_session(
+                    session_id=session_id,
+                    message=message,
+                    is_first=False,
+                )
+        except Exception as e:
+            logger.error("claude session call failed: %s", e)
+            # try recovery: invalidate and retry as fresh session
+            self.session_mgr.invalidate_session(db)
+            try:
+                session_id = self.session_mgr.get_or_create_session_id(db, today)
+                raw_text = await _call_claude_session(
+                    session_id=session_id,
+                    message=f"Current context:\n{context}\n\n{message}",
+                    is_first=True,
+                    system_prompt=SYSTEM_PROMPT,
+                )
+            except Exception as e2:
+                logger.error("claude recovery failed: %s", e2)
+                return self._error_response()
+
+        # parse response
+        try:
+            parsed = json.loads(raw_text)
+        except json.JSONDecodeError:
+            return {"response": raw_text, "layout": None, "profile": None, "memory_update": None, "training_log_entry": None, "set_suggestion": None, "meal": None, "workout_plan": None}
+
+        # handle tool calls — 2nd call within the same session
+        tool_calls = parsed.get("tool_calls", [])
+        if tool_calls and db:
+            from server.services.whoop_tools import execute_whoop_tool
+            results = []
+            for tc in tool_calls:
+                result = await execute_whoop_tool(tc["name"], tc.get("arguments", {}), db)
+                results.append({"tool": tc["name"], "result": result})
+            try:
+                followup_text = await _call_claude_session(
+                    session_id=session_id,
+                    message=f"Tool results: {json.dumps(results)}",
+                    is_first=False,
+                )
+                try:
+                    parsed = json.loads(followup_text)
+                except json.JSONDecodeError:
+                    parsed["response"] = followup_text
+            except Exception:
+                pass
+
+        layout = parsed.get("layout")
+        if layout:
+            validation = validate_layout(layout)
+            layout = validation["layout"] if validation["valid"] else None
+
+        return {
+            "response": parsed.get("response", raw_text),
+            "layout": layout,
+            "profile": parsed.get("profile"),
+            "memory_update": parsed.get("memory_update"),
+            "training_log_entry": parsed.get("training_log_entry"),
+            "set_suggestion": parsed.get("set_suggestion"),
+            "meal": parsed.get("meal"),
+            "workout_plan": parsed.get("workout_plan"),
+        }
+
+    async def _chat_stateless(self, message: str, context: str) -> dict:
+        """fallback for calls without a db session (unit tests, intake)"""
         system = f"{SYSTEM_PROMPT}\n\nCurrent context:\n{context}"
         try:
             raw_text = await _call_claude_stateless(system, message)
         except Exception as e:
             logger.error("claude call failed: %s", e)
-            return {"response": "Having trouble reaching Claude right now. Try again in a sec.", "layout": None, "profile": None, "memory_update": None, "training_log_entry": None, "set_suggestion": None, "meal": None, "workout_plan": None}
+            return self._error_response()
         try:
             parsed = json.loads(raw_text)
         except json.JSONDecodeError:
@@ -322,6 +417,41 @@ class ClaudeService:
             "meal": parsed.get("meal"),
             "workout_plan": parsed.get("workout_plan"),
         }
+
+    _handoff_lock = asyncio.Lock()
+
+    async def _do_handoff(self, db, today: str):
+        """summarize old session and create new one"""
+        async with self._handoff_lock:
+            if not self.session_mgr.needs_handoff(db, today):
+                return
+            old_id, old_date = self.session_mgr.get_old_session(db)
+            if not old_id:
+                return
+            try:
+                summary_text = await _call_claude_session(
+                    session_id=old_id,
+                    message="Summarize today's coaching session in 2-3 sentences. Include: what was trained, key performance notes, any program adjustments discussed, and anything to carry forward to tomorrow.",
+                    is_first=False,
+                )
+                try:
+                    summary_parsed = json.loads(summary_text)
+                    summary_content = summary_parsed.get("response", summary_text)
+                except json.JSONDecodeError:
+                    summary_content = summary_text
+                from server.models import TrainingLog
+                db.add(TrainingLog(
+                    date=old_date or today,
+                    log_type="daily_summary",
+                    content=summary_content[:500],
+                ))
+                db.commit()
+            except Exception as e:
+                logger.warning("session handoff summary failed: %s", e)
+            self.session_mgr.invalidate_session(db)
+
+    def _error_response(self):
+        return {"response": "Having trouble reaching Claude right now. Try again in a sec.", "layout": None, "profile": None, "memory_update": None, "training_log_entry": None, "set_suggestion": None, "meal": None, "workout_plan": None}
 
     async def generate_interview_questions(self, profile_summary: str) -> list[str]:
         """generate personalized interview questions for onboarding."""

--- a/server/services/program_parser.py
+++ b/server/services/program_parser.py
@@ -72,14 +72,54 @@ def _parse_templates(content: str, schedule: dict) -> dict:
                 break
         if not section:
             continue
-        lines = [
-            l.strip().lstrip('- ')
-            for l in section.split('\n')
-            if l.strip() and not l.strip().startswith('#')
-        ]
+        lines = []
+        for l in section.split('\n'):
+            l = l.strip()
+            if not l or l.startswith('#'):
+                continue
+            # skip status/metadata lines
+            l_lower = l.lower()
+            if any(kw in l_lower for kw in ['status:', 'completed', 'duration:', 'workout duration']):
+                continue
+            # strip markdown bold/emphasis and list markers
+            l = l.lstrip('- ')
+            l = l.replace('**', '').replace('*', '')
+            # strip numbered prefixes (e.g. "1. ", "2. ")
+            l = re.sub(r'^\d+\.\s*', '', l)
+            # extract just exercise name from detailed entries
+            # e.g. "Pull-ups: 5 sets (8,7,6,6,5 reps) - Bodyweight" → "Pull-ups 5 sets"
+            colon_match = re.match(r'^([^:]+):\s*(.+)$', l)
+            if colon_match:
+                name = colon_match.group(1).strip()
+                detail = colon_match.group(2).strip()
+                # extract set/rep scheme, drop parenthetical details and annotations
+                scheme = re.match(r'(\d+\s*sets?\s*(?:x\s*[\d\-]+)?|\d+x[\d\-]+)', detail)
+                if scheme:
+                    l = f"{name} {scheme.group(1).strip()}"
+                else:
+                    l = name
+            if l:
+                lines.append(l)
         if lines:
             templates[day_type] = ', '.join(lines)
     return templates
+
+
+def _parse_week_start_date(title: str) -> str | None:
+    """extract a start date from week title like 'started 3/15' or 'Sun 3/22'"""
+    from datetime import date as dt_date
+    current_year = dt_date.today().year
+    # "started M/D"
+    m = re.search(r'started\s+(\d{1,2})/(\d{1,2})', title)
+    if m:
+        month, day = int(m.group(1)), int(m.group(2))
+        return dt_date(current_year, month, day).isoformat()
+    # "Sun M/D" or "M/D" as first date mention
+    m = re.search(r'(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)\s+(\d{1,2})/(\d{1,2})', title)
+    if m:
+        month, day = int(m.group(1)), int(m.group(2))
+        return dt_date(current_year, month, day).isoformat()
+    return None
 
 
 def _parse_weeks(content: str, schedule: dict, templates: dict) -> list:
@@ -90,6 +130,9 @@ def _parse_weeks(content: str, schedule: dict, templates: dict) -> list:
 
     for i, match in enumerate(matches):
         title = match.group(1).strip()
+        # strip markdown bold/emphasis and emoji artifacts
+        title = title.replace('**', '').replace('*', '')
+        title = re.sub(r'[✅❌⬜🔲]\s*', '', title).strip()
         start = match.end()
         end = matches[i + 1].start() if i + 1 < len(matches) else len(content)
         body = content[start:end].strip()
@@ -97,13 +140,19 @@ def _parse_weeks(content: str, schedule: dict, templates: dict) -> list:
         items = []
         for line in body.split('\n'):
             line = line.strip()
+            # strip markdown bold/emphasis from items too
+            line = line.replace('**', '').replace('*', '')
             if line.startswith('- '):
                 items.append(line[2:].strip())
 
         week_num_match = re.search(r'Week (\d+)', title)
         week_num = int(week_num_match.group(1)) if week_num_match else len(weeks) + 1
+
+        # parse start date from title (e.g. "started 3/15" or "Sun 3/22")
+        start_date = _parse_week_start_date(title)
+
         days = _build_days(schedule, templates, items)
-        weeks.append({"number": week_num, "title": title, "days": days})
+        weeks.append({"number": week_num, "title": title, "days": days, "start_date": start_date})
 
     return weeks
 
@@ -112,6 +161,7 @@ def _build_days(schedule: dict, templates: dict, items: list) -> list:
     """build day list from schedule, templates, and week-specific items"""
     days = []
     visited_compound = set()
+    matched_items: set[int] = set()
 
     for day_abbrev in DAY_ORDER:
         day_type = schedule.get(day_abbrev, "")
@@ -132,12 +182,15 @@ def _build_days(schedule: dict, templates: dict, items: list) -> list:
         note = ""
         status = "upcoming"
 
-        for item in items:
+        for idx, item in enumerate(items):
+            if idx in matched_items:
+                continue
             item_lower = item.lower()
             type_first_word = day_type.lower().split()[0]
             if type_first_word not in item_lower:
                 continue
 
+            matched_items.add(idx)
             colon_idx = item.find(':')
             raw = item[colon_idx + 1:].strip() if colon_idx > 0 else item
 
@@ -163,6 +216,17 @@ def _build_days(schedule: dict, templates: dict, items: list) -> list:
             "note": note,
             "status": status,
         })
+
+    # second pass: assign unmatched items containing weight patterns to bench days
+    unmatched = [items[i] for i in range(len(items)) if i not in matched_items]
+    if unmatched:
+        for item in unmatched:
+            if not re.search(r'\d{2,3}x\d', item):
+                continue
+            for day in days:
+                if 'bench' in day["type"].lower() and not day["planned"]:
+                    day["planned"] = item
+                    break
 
     return days
 

--- a/server/services/session_manager.py
+++ b/server/services/session_manager.py
@@ -1,0 +1,73 @@
+import json
+import logging
+import os
+import uuid
+
+from server.models import SystemMemory
+
+logger = logging.getLogger(__name__)
+
+SESSION_KEY = "active_session"
+SESSIONS_DIR = os.path.expanduser("~/.claude/projects/-home-deck-spotme")
+
+
+class SessionManager:
+
+    def get_or_create_session_id(self, db, today: str) -> str:
+        row = db.query(SystemMemory).filter_by(key=SESSION_KEY).first()
+        if row and row.content:
+            data = json.loads(row.content)
+            if data.get("date") == today:
+                return data["session_id"]
+            # new day — delete old session file, create new
+            self._delete_session_file(data.get("session_id"))
+
+        new_id = str(uuid.uuid4())
+        payload = json.dumps({"session_id": new_id, "date": today})
+        if row:
+            row.content = payload
+        else:
+            db.add(SystemMemory(key=SESSION_KEY, content=payload))
+        db.commit()
+        return new_id
+
+    def is_first_message(self, db, today: str) -> bool:
+        row = db.query(SystemMemory).filter_by(key=SESSION_KEY).first()
+        if not row or not row.content:
+            return True
+        data = json.loads(row.content)
+        return data.get("date") != today
+
+    def needs_handoff(self, db, today: str) -> bool:
+        row = db.query(SystemMemory).filter_by(key=SESSION_KEY).first()
+        if not row or not row.content:
+            return False
+        data = json.loads(row.content)
+        return data.get("date") != today and data.get("session_id") is not None
+
+    def get_old_session(self, db) -> tuple[str | None, str | None]:
+        """return (session_id, date) of the old session, or (None, None)"""
+        row = db.query(SystemMemory).filter_by(key=SESSION_KEY).first()
+        if not row or not row.content:
+            return None, None
+        data = json.loads(row.content)
+        return data.get("session_id"), data.get("date")
+
+    def invalidate_session(self, db):
+        row = db.query(SystemMemory).filter_by(key=SESSION_KEY).first()
+        if row:
+            if row.content:
+                data = json.loads(row.content)
+                self._delete_session_file(data.get("session_id"))
+            db.delete(row)
+            db.commit()
+
+    def _delete_session_file(self, session_id: str | None):
+        if not session_id:
+            return
+        path = os.path.join(SESSIONS_DIR, f"{session_id}.jsonl")
+        try:
+            os.remove(path)
+            logger.info("deleted session file: %s", path)
+        except FileNotFoundError:
+            pass

--- a/server/services/session_manager.py
+++ b/server/services/session_manager.py
@@ -2,10 +2,21 @@ import json
 import logging
 import os
 import uuid
+from datetime import datetime, timedelta
 
+from server.config import TIMEZONE, SESSION_ROLLOVER_HOUR
 from server.models import SystemMemory
 
 logger = logging.getLogger(__name__)
+
+
+def session_date(now: datetime | None = None) -> str:
+    """return the effective session date, treating hours before SESSION_ROLLOVER_HOUR as previous day"""
+    if now is None:
+        now = datetime.now(TIMEZONE)
+    if now.hour < SESSION_ROLLOVER_HOUR:
+        now = now - timedelta(days=1)
+    return now.strftime("%Y-%m-%d")
 
 SESSION_KEY = "active_session"
 SESSIONS_DIR = os.path.expanduser("~/.claude/projects/-home-deck-spotme")
@@ -19,8 +30,7 @@ class SessionManager:
             data = json.loads(row.content)
             if data.get("date") == today:
                 return data["session_id"]
-            # new day — delete old session file, create new
-            self._delete_session_file(data.get("session_id"))
+            # new day — overwrite db row (caller handles file cleanup via invalidate_session)
 
         new_id = str(uuid.uuid4())
         payload = json.dumps({"session_id": new_id, "date": today})

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -136,7 +136,7 @@ def test_recovery_zone_none_score():
 
 @pytest.mark.asyncio
 async def test_chat_returns_text_and_layout():
-    with patch("server.services.claude_service._call_claude", new_callable=AsyncMock) as mock_call:
+    with patch("server.services.claude_service._call_claude_stateless", new_callable=AsyncMock) as mock_call:
         mock_call.return_value = '{"response": "Go heavy today", "layout": {"screen": "workout_session", "layout": [{"type": "header", "title": "Bench Day"}]}}'
         service = ClaudeService()
         result = await service.chat("what's my workout?", context="test context")
@@ -146,7 +146,7 @@ async def test_chat_returns_text_and_layout():
 
 @pytest.mark.asyncio
 async def test_chat_extracts_profile():
-    with patch("server.services.claude_service._call_claude", new_callable=AsyncMock) as mock_call:
+    with patch("server.services.claude_service._call_claude_stateless", new_callable=AsyncMock) as mock_call:
         mock_call.return_value = '{"response": "Nice to meet you!", "layout": null, "profile": {"name": "Jordan", "goals": "strength"}}'
         service = ClaudeService()
         result = await service.chat("I'm Jordan", context="test")
@@ -158,7 +158,7 @@ async def test_chat_extracts_profile():
 
 @pytest.mark.asyncio
 async def test_chat_returns_set_suggestion():
-    with patch("server.services.claude_service._call_claude", new_callable=AsyncMock) as mock_call:
+    with patch("server.services.claude_service._call_claude_stateless", new_callable=AsyncMock) as mock_call:
         mock_call.return_value = '{"response": "Hit 225 for 5 reps", "layout": null, "set_suggestion": {"exercise": "Bench Press", "weight": 225, "reps": 5, "basis": "based on last session"}}'
         service = ClaudeService()
         result = await service.chat("what should I do next?", context="test")
@@ -170,7 +170,7 @@ async def test_chat_returns_set_suggestion():
 
 @pytest.mark.asyncio
 async def test_chat_set_suggestion_null_when_absent():
-    with patch("server.services.claude_service._call_claude", new_callable=AsyncMock) as mock_call:
+    with patch("server.services.claude_service._call_claude_stateless", new_callable=AsyncMock) as mock_call:
         mock_call.return_value = '{"response": "Just chatting", "layout": null}'
         service = ClaudeService()
         result = await service.chat("how are you?", context="test")
@@ -179,7 +179,7 @@ async def test_chat_set_suggestion_null_when_absent():
 
 @pytest.mark.asyncio
 async def test_chat_set_suggestion_null_on_parse_failure():
-    with patch("server.services.claude_service._call_claude", new_callable=AsyncMock) as mock_call:
+    with patch("server.services.claude_service._call_claude_stateless", new_callable=AsyncMock) as mock_call:
         mock_call.return_value = "plain text, not json"
         service = ClaudeService()
         result = await service.chat("hello", context="test")

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -1,0 +1,111 @@
+import json
+import pytest
+from unittest.mock import patch, AsyncMock
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from server.database import Base, get_db
+from server.models import SystemMemory, UserProfile, Conversation
+from server.config import today_eastern
+
+
+def _make_app():
+    from server.main import create_app
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine)
+    def override():
+        db = TestSession()
+        try: yield db
+        finally: db.close()
+    app = create_app()
+    app.dependency_overrides[get_db] = override
+    return TestClient(app), TestSession
+
+
+def test_chat_creates_session_on_first_message():
+    client, TestSession = _make_app()
+    db = TestSession()
+    db.add(UserProfile(name="Test"))
+    db.commit()
+    db.close()
+
+    mock_response = json.dumps({"response": "Hey! Ready to train.", "layout": None})
+    with patch("server.services.claude_service._call_claude_session", new_callable=AsyncMock, return_value=mock_response):
+        resp = client.post("/api/chat", json={"message": "hi", "workout_id": None, "date": None})
+    assert resp.status_code == 200
+    assert "Ready to train" in resp.json()["response"]
+
+    db = TestSession()
+    session_row = db.query(SystemMemory).filter_by(key="active_session").first()
+    assert session_row is not None
+    data = json.loads(session_row.content)
+    assert data["date"] == today_eastern()
+    db.close()
+
+
+def test_chat_resumes_existing_session():
+    client, TestSession = _make_app()
+    db = TestSession()
+    db.add(UserProfile(name="Test"))
+    db.add(SystemMemory(key="active_session", content=json.dumps({"session_id": "existing-uuid", "date": today_eastern()})))
+    db.commit()
+    db.close()
+
+    mock_response = json.dumps({"response": "Welcome back.", "layout": None})
+    with patch("server.services.claude_service._call_claude_session", new_callable=AsyncMock, return_value=mock_response) as mock_call:
+        resp = client.post("/api/chat", json={"message": "hey", "workout_id": None, "date": None})
+    assert resp.status_code == 200
+    # check that it used resume (is_first=False)
+    call_kwargs = mock_call.call_args
+    assert call_kwargs.kwargs.get("is_first") is False or (len(call_kwargs.args) > 2 and call_kwargs.args[2] is False)
+
+
+def test_memory_update_allowed_with_training_log():
+    """memory_update should no longer be blocked when training_log_entry is present"""
+    client, TestSession = _make_app()
+    db = TestSession()
+    db.add(UserProfile(name="Test"))
+    db.add(SystemMemory(key="training_plan", content="original program text that is long enough"))
+    db.commit()
+    db.close()
+
+    mock_response = json.dumps({
+        "response": "Updated your program and logged the completion.",
+        "layout": None,
+        "memory_update": "updated program text that is about the same length as before",
+        "training_log_entry": {"type": "completion", "day": "Heavy Bench", "summary": "265x4"},
+    })
+    with patch("server.services.claude_service._call_claude_session", new_callable=AsyncMock, return_value=mock_response):
+        resp = client.post("/api/chat", json={"message": "update program", "workout_id": None, "date": None})
+    assert resp.status_code == 200
+
+    db = TestSession()
+    mem = db.query(SystemMemory).filter_by(key="training_plan").first()
+    assert mem.content == "updated program text that is about the same length as before"
+    db.close()
+
+
+def test_memory_update_blocked_if_truncated():
+    """memory_update should be blocked if >50% shorter than existing"""
+    client, TestSession = _make_app()
+    db = TestSession()
+    db.add(UserProfile(name="Test"))
+    db.add(SystemMemory(key="training_plan", content="a" * 1000))
+    db.commit()
+    db.close()
+
+    mock_response = json.dumps({
+        "response": "Here's the update.",
+        "layout": None,
+        "memory_update": "short",
+    })
+    with patch("server.services.claude_service._call_claude_session", new_callable=AsyncMock, return_value=mock_response):
+        resp = client.post("/api/chat", json={"message": "update", "workout_id": None, "date": None})
+    assert resp.status_code == 200
+
+    db = TestSession()
+    mem = db.query(SystemMemory).filter_by(key="training_plan").first()
+    assert mem.content == "a" * 1000  # unchanged, blocked
+    db.close()

--- a/tests/test_claude_sdk.py
+++ b/tests/test_claude_sdk.py
@@ -1,6 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
-from unittest import mock
+from unittest.mock import AsyncMock, patch
 
 
 async def _mock_wait_for(coro, timeout):
@@ -9,9 +8,9 @@ async def _mock_wait_for(coro, timeout):
 
 
 @pytest.mark.asyncio
-async def test_call_claude_returns_json_response():
-    """_call_claude uses CLI subprocess and returns parsed JSON."""
-    from server.services.claude_service import _call_claude
+async def test_call_claude_stateless_returns_json_response():
+    """_call_claude_stateless uses CLI subprocess and returns parsed JSON."""
+    from server.services.claude_service import _call_claude_stateless
 
     proc = AsyncMock()
     proc.communicate.return_value = (b'{"response": "test reply", "layout": null}', b"")
@@ -19,16 +18,16 @@ async def test_call_claude_returns_json_response():
 
     with patch("asyncio.create_subprocess_exec", return_value=proc):
         with patch("asyncio.wait_for", side_effect=_mock_wait_for):
-            result = await _call_claude("test system prompt", "hello")
+            result = await _call_claude_stateless("test system prompt", "hello")
 
     assert '"response"' in result
     assert "test reply" in result
 
 
 @pytest.mark.asyncio
-async def test_call_claude_extracts_json_from_fenced_response():
-    """_call_claude applies _extract_json to strip markdown fences."""
-    from server.services.claude_service import _call_claude
+async def test_call_claude_stateless_extracts_json_from_fenced_response():
+    """_call_claude_stateless applies _extract_json to strip markdown fences."""
+    from server.services.claude_service import _call_claude_stateless
 
     proc = AsyncMock()
     proc.communicate.return_value = (b'```json\n{"response": "fenced", "layout": null}\n```', b"")
@@ -36,16 +35,16 @@ async def test_call_claude_extracts_json_from_fenced_response():
 
     with patch("asyncio.create_subprocess_exec", return_value=proc):
         with patch("asyncio.wait_for", side_effect=_mock_wait_for):
-            result = await _call_claude("sys", "msg")
+            result = await _call_claude_stateless("sys", "msg")
 
     assert '"response"' in result
     assert "```" not in result
 
 
 @pytest.mark.asyncio
-async def test_call_claude_raises_on_cli_error():
-    """_call_claude raises RuntimeError on non-zero exit code."""
-    from server.services.claude_service import _call_claude
+async def test_call_claude_stateless_raises_on_cli_error():
+    """_call_claude_stateless raises RuntimeError on non-zero exit code."""
+    from server.services.claude_service import _call_claude_stateless
 
     proc = AsyncMock()
     proc.communicate.return_value = (b"", b"auth failed")
@@ -54,41 +53,4 @@ async def test_call_claude_raises_on_cli_error():
     with patch("asyncio.create_subprocess_exec", return_value=proc):
         with patch("asyncio.wait_for", side_effect=_mock_wait_for):
             with pytest.raises(RuntimeError, match="claude cli failed"):
-                await _call_claude("sys", "msg")
-
-
-@pytest.mark.asyncio
-async def test_tool_use_loop_executes_tool():
-    """When Claude returns tool_calls, server executes and sends results back."""
-    from server.services.claude_service import _call_claude_with_tools
-
-    first_response = '{"response": "logging sauna", "tool_calls": [{"name": "create_whoop_activity", "arguments": {"activity_type": "sauna", "duration_minutes": 20}}]}'
-    second_response = '{"response": "Logged 20-min sauna to Whoop.", "layout": null}'
-
-    with patch("server.services.claude_service._call_claude", new_callable=AsyncMock) as mock_call:
-        mock_call.side_effect = [first_response, second_response]
-        mock_tool_executor = AsyncMock(return_value={"success": True, "activity_id": "uuid-123"})
-
-        result = await _call_claude_with_tools(
-            system_prompt="test",
-            message="log a sauna",
-            tools=[{
-                "name": "create_whoop_activity",
-                "description": "Log an activity",
-                "input_schema": {
-                    "type": "object",
-                    "properties": {"activity_type": {"type": "string"}, "duration_minutes": {"type": "integer"}},
-                    "required": ["activity_type", "duration_minutes"],
-                },
-            }],
-            tool_executor=mock_tool_executor,
-            db=MagicMock(),
-        )
-
-    assert "Logged 20-min sauna" in result
-    mock_tool_executor.assert_called_once_with(
-        "create_whoop_activity",
-        {"activity_type": "sauna", "duration_minutes": 20},
-        mock.ANY,
-    )
-    assert mock_call.call_count == 2
+                await _call_claude_stateless("sys", "msg")

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -4,7 +4,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 from server.database import Base, get_db
-from server.models import SystemMemory, Program, Workout
+from server.models import SystemMemory, Program, Workout, Exercise
 
 SAMPLE_PLAN = """## Weekly Schedule
 - Friday: Pull / Back
@@ -130,10 +130,13 @@ def test_program_stats():
     program = Program(name="Test", goal="315", phase="peak")
     db.add(program)
     db.commit()
-    db.add(Workout(
+    w1 = Workout(
         program_id=program.id, date=date.today().isoformat(),
         type="strength", status="completed", duration=45,
-    ))
+    )
+    db.add(w1)
+    db.flush()
+    db.add(Exercise(workout_id=w1.id, name="Bench Press", order=1))
     db.add(Workout(
         program_id=program.id, date=date.today().isoformat(),
         type="strength", status="active",

--- a/tests/test_session_calls.py
+++ b/tests/test_session_calls.py
@@ -1,0 +1,90 @@
+import asyncio
+import json
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from server.services.claude_service import (
+    _call_claude_session,
+    _call_claude_stateless,
+    _session_lock,
+)
+
+
+@pytest.fixture
+def mock_subprocess():
+    proc = AsyncMock()
+    proc.returncode = 0
+    proc.communicate = AsyncMock(return_value=(
+        json.dumps({"response": "test reply"}).encode(),
+        b"",
+    ))
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+    return proc
+
+
+async def _mock_wait_for(coro, timeout):
+    """await the coroutine like real wait_for does."""
+    return await coro
+
+
+@pytest.mark.asyncio
+async def test_session_call_uses_resume(mock_subprocess):
+    with patch("asyncio.create_subprocess_exec", return_value=mock_subprocess) as mock_exec:
+        with patch("asyncio.wait_for", side_effect=_mock_wait_for):
+            result = await _call_claude_session(
+                session_id="abc-123",
+                message="hello",
+                is_first=False,
+            )
+            args = mock_exec.call_args[0]
+            assert "--resume" in args
+            assert "abc-123" in args
+            assert "--session-id" not in args
+
+
+@pytest.mark.asyncio
+async def test_session_call_uses_session_id_for_first(mock_subprocess):
+    with patch("asyncio.create_subprocess_exec", return_value=mock_subprocess) as mock_exec:
+        with patch("asyncio.wait_for", side_effect=_mock_wait_for):
+            result = await _call_claude_session(
+                session_id="abc-123",
+                message="hello",
+                is_first=True,
+                system_prompt="you are a coach",
+            )
+            args = mock_exec.call_args[0]
+            assert "--session-id" in args
+            assert "abc-123" in args
+            assert "--append-system-prompt" in args
+
+
+@pytest.mark.asyncio
+async def test_stateless_call_uses_no_session_persistence(mock_subprocess):
+    with patch("asyncio.create_subprocess_exec", return_value=mock_subprocess) as mock_exec:
+        with patch("asyncio.wait_for", side_effect=_mock_wait_for):
+            result = await _call_claude_stateless("system", "message")
+            args = mock_exec.call_args[0]
+            assert "--no-session-persistence" in args
+            assert "--resume" not in args
+
+
+@pytest.mark.asyncio
+async def test_session_lock_prevents_concurrent_calls(mock_subprocess):
+    call_order = []
+
+    async def slow_communicate():
+        call_order.append("start")
+        await asyncio.sleep(0.1)
+        call_order.append("end")
+        return (json.dumps({"response": "ok"}).encode(), b"")
+
+    mock_subprocess.communicate = slow_communicate
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_subprocess):
+        with patch("asyncio.wait_for", side_effect=_mock_wait_for):
+            await asyncio.gather(
+                _call_claude_session("id", "msg1", is_first=False),
+                _call_claude_session("id", "msg2", is_first=False),
+            )
+    assert call_order == ["start", "end", "start", "end"]

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,12 +1,14 @@
 import json
 import pytest
+from datetime import datetime
 from unittest.mock import AsyncMock, patch, MagicMock
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 from server.database import Base
+from server.config import TIMEZONE
 from server.models import SystemMemory
-from server.services.session_manager import SessionManager
+from server.services.session_manager import SessionManager, session_date
 
 
 def _make_db():
@@ -73,3 +75,23 @@ def test_invalidate_session():
     mgr.get_or_create_session_id(db, "2026-03-23")
     mgr.invalidate_session(db)
     assert mgr.is_first_message(db, "2026-03-23") is True
+
+
+def test_session_date_before_rollover_returns_yesterday():
+    fake_now = datetime(2026, 3, 23, 3, 0, tzinfo=TIMEZONE)
+    assert session_date(now=fake_now) == "2026-03-22"
+
+
+def test_session_date_after_rollover_returns_today():
+    fake_now = datetime(2026, 3, 23, 5, 0, tzinfo=TIMEZONE)
+    assert session_date(now=fake_now) == "2026-03-23"
+
+
+def test_session_date_at_exactly_rollover_returns_today():
+    fake_now = datetime(2026, 3, 23, 4, 0, tzinfo=TIMEZONE)
+    assert session_date(now=fake_now) == "2026-03-23"
+
+
+def test_session_date_at_midnight_returns_yesterday():
+    fake_now = datetime(2026, 3, 23, 0, 0, tzinfo=TIMEZONE)
+    assert session_date(now=fake_now) == "2026-03-22"

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,0 +1,75 @@
+import json
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from server.database import Base
+from server.models import SystemMemory
+from server.services.session_manager import SessionManager
+
+
+def _make_db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_get_session_creates_new_when_none_exists():
+    db = _make_db()
+    mgr = SessionManager()
+    session_id = mgr.get_or_create_session_id(db, "2026-03-23")
+    assert session_id is not None
+    row = db.query(SystemMemory).filter_by(key="active_session").first()
+    assert row is not None
+    data = json.loads(row.content)
+    assert data["session_id"] == session_id
+    assert data["date"] == "2026-03-23"
+
+
+def test_get_session_reuses_existing_same_day():
+    db = _make_db()
+    mgr = SessionManager()
+    id1 = mgr.get_or_create_session_id(db, "2026-03-23")
+    id2 = mgr.get_or_create_session_id(db, "2026-03-23")
+    assert id1 == id2
+
+
+def test_get_session_creates_new_on_new_day():
+    db = _make_db()
+    mgr = SessionManager()
+    old_id = mgr.get_or_create_session_id(db, "2026-03-22")
+    new_id = mgr.get_or_create_session_id(db, "2026-03-23")
+    assert old_id != new_id
+    row = db.query(SystemMemory).filter_by(key="active_session").first()
+    data = json.loads(row.content)
+    assert data["date"] == "2026-03-23"
+
+
+def test_is_first_message_of_day():
+    db = _make_db()
+    mgr = SessionManager()
+    assert mgr.is_first_message(db, "2026-03-23") is True
+    mgr.get_or_create_session_id(db, "2026-03-23")
+    assert mgr.is_first_message(db, "2026-03-23") is False
+
+
+def test_needs_handoff():
+    db = _make_db()
+    mgr = SessionManager()
+    mgr.get_or_create_session_id(db, "2026-03-22")
+    assert mgr.needs_handoff(db, "2026-03-23") is True
+    assert mgr.needs_handoff(db, "2026-03-22") is False
+
+
+def test_invalidate_session():
+    db = _make_db()
+    mgr = SessionManager()
+    mgr.get_or_create_session_id(db, "2026-03-23")
+    mgr.invalidate_session(db)
+    assert mgr.is_first_message(db, "2026-03-23") is True


### PR DESCRIPTION
## Summary

- **Daily session architecture**: Replace per-message Claude CLI subprocess spawning (211 stale sessions, 84MB) with 1 session per day. Session state persists on disk, processes exit after each response. Daily handoff summarizes old session into TrainingLog before creating new one.
- **SSE streaming**: Chat responses now stream token-by-token via `--output-format stream-json`. Active workout chat stays non-streaming.
- **2-call tool-use**: Whoop tool calls execute in 2 session-aware calls (down from 3 blind stateless calls). Claude has full conversation context for tool follow-ups.
- **Program tab fixes**: Exercise-name matching for workouts (not type keyword), per-day expected dates, current week detection from parsed start dates, cleaned up template extraction.
- **Unblocked memory updates**: `memory_update` + `training_log_entry` can coexist (with >50% truncation guard).

## Key changes

| Area | Before | After |
|------|--------|-------|
| Session files | 211 (84MB) | 1 (<1MB) |
| Tool-use calls | 3 stateless | 2 in-session |
| Context per message | ~4000 tokens every time | ~200 tokens after first |
| Chat UX | Wait 10-60s for full response | Tokens stream as generated |
| Workout matching | `type="strength"` keyword (broken) | Exercise-name scoring |
| Week detection | "current" keyword in title | Parsed start dates |

## New files
- `server/services/session_manager.py` — daily session lifecycle
- `server/routes/chat_stream.py` — SSE streaming endpoint
- `tests/test_session_manager.py`, `tests/test_session_calls.py`, `tests/test_chat_session.py`

## Test plan
- [ ] 157 backend tests passing
- [ ] Frontend TypeScript compiles clean
- [ ] Frontend builds successfully
- [ ] Send chat message — verify session created (1 file in `~/.claude/projects/`)
- [ ] Send second message — verify session resumed (still 1 file)
- [ ] Daily chat streams token-by-token
- [ ] Active workout chat returns full response (non-streaming)
- [ ] Program tab: Week 2 shows Pull/Back + Heavy Bench completed, Legs TBD
- [ ] Program tab: Week 5 shows test day plan
- [ ] Whoop tool use (e.g. "log my sauna") completes in 2 calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)